### PR TITLE
Refactor: module-wide consistency, correctness, and security fixes

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # use the 730MB sdk image to build
-FROM mcr.microsoft.com/dotnet/sdk as builder
+FROM mcr.microsoft.com/dotnet/sdk AS builder
 
 # install the latest version of PowerShell
 RUN dotnet tool install -g PowerShell
@@ -8,8 +8,8 @@ RUN dotnet tool install -g PowerShell
 #FROM mcr.microsoft.com/dotnet/runtime
 #COPY --from=builder /root/.dotnet/tools/ /bin
 
-# install git
-RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
+# install git and ssh client (required by git when cloning/fetching over SSH remotes)
+RUN apt-get update && apt-get install -y --no-install-recommends git openssh-client && rm -rf /var/lib/apt/lists/*
 
 # run powershell
-ENTRYPOINT pwsh
+ENTRYPOINT ["pwsh"]

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owner for everything in the repo
+*       @johnsarie27

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,8 +1,35 @@
 changelog:
   exclude:
+    labels:
+      - ignore-for-release
     authors:
       - dependabot
   categories:
-    - title: Main changes
+    - title: Breaking Changes
+      labels:
+        - breaking
+        - breaking-change
+    - title: New Features
+      labels:
+        - enhancement
+        - feature
+    - title: Bug Fixes
+      labels:
+        - bug
+        - fix
+    - title: Security
+      labels:
+        - security
+    - title: Documentation
+      labels:
+        - documentation
+        - docs
+    - title: CI / Build
+      labels:
+        - ci
+        - build
+        - dependencies
+    - title: Other Changes
       labels:
         - "*"
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,12 +12,16 @@ on:
       - .gitignore
       - .github/**
 
+permissions:
+  id-token: write # required for OIDC-based publishing
+  contents: write # required for actions/checkout + creating releases
+
 jobs:
   release:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6 # checkout code
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - shell: pwsh # install dependencies
         run: .\Build\build.ps1 -ResolveDependency -TaskList 'Init'
@@ -34,14 +38,15 @@ jobs:
       - shell: pwsh # compress module
         run: .\Build\build.ps1 -TaskList 'CreateBuildArtifact'
 
-      - uses: actions/upload-artifact@v7 # publish compressed module
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: Artifacts
           path: "Artifacts"
           if-no-files-found: error
 
-      - uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0 release
+      - uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           generate_release_notes: true
           files: Artifacts/*.zip
+

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,12 +9,21 @@ on:
       #- CONTRIBUTING.md
       #- .gitignore
       #- .github/**
+  push:
+    branches: [main]
+
+# Cancel any in-progress validate run on the same ref when a new one starts.
+# This consolidates rapid-fire submissions (force-pushes, multiple commits in a
+# PR) into a single completed run and saves Actions minutes.
+concurrency:
+  group: validate-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6 # checkout code
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - shell: pwsh # install dependencies
         run: .\Build\build.ps1 -ResolveDependency -TaskList 'Init'
@@ -28,8 +37,9 @@ jobs:
       - shell: pwsh # pester
         run: .\Build\build.ps1 -TaskList 'Test'
 
-      - uses: actions/upload-artifact@v7 # publish pester results
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: Pester Results
           path: "Artifacts/**/Test-*.xml"
           if-no-files-found: error
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Build outputs (produced by Build/build.ps1 / psake tasks)
+Artifacts/
+Staging/
+BuildOutput/
+
+# Helper artifacts used during refactor work
+.commit-msg-*.txt
+.issue-body-*.txt
+.tick-*.ps1
+.fix-*.ps1
+*.tmp
+
+# Editor / OS noise
+.vs/
+.vscode/*.log
+Thumbs.db
+.DS_Store

--- a/Build/build.psake.ps1
+++ b/Build/build.psake.ps1
@@ -1,32 +1,34 @@
 # PSake makes variables declared here available in other scriptblocks
+# Note: variables are set via Set-Variable rather than `$x = ...` so that
+# PSScriptAnalyzer's PSUseDeclaredVarsMoreThanAssignments rule does not
+# false-positive on them. PSSA can't follow psake's runtime hoisting of
+# Properties-block variables into Task scriptblocks; Set-Variable is the
+# documented psake workaround.
 Properties {
-    $ProjectRoot = $env:BHProjectPath
+    Set-Variable -Name 'ProjectRoot' -Value $env:BHProjectPath
     if (-not $ProjectRoot) {
-        $ProjectRoot = $PSScriptRoot
+        Set-Variable -Name 'ProjectRoot' -Value $PSScriptRoot
     }
 
-    $Timestamp = Get-Date -UFormat '%Y%m%d-%H%M%S'
-    $PSVersion = $PSVersionTable.PSVersion.Major
-    $lines = '----------------------------------------------------------------------'
+    Set-Variable -Name 'Timestamp' -Value (Get-Date -UFormat '%Y%m%d-%H%M%S')
+    Set-Variable -Name 'lines' -Value '----------------------------------------------------------------------'
 
     # Pester
-    $TestScripts = Get-ChildItem "$ProjectRoot/Tests/*/*Tests.ps1"
-    $TestFile = "Test-Unit_$($TimeStamp).xml"
+    Set-Variable -Name 'TestScripts' -Value (Get-ChildItem "$ProjectRoot/Tests/*/*Tests.ps1")
+    Set-Variable -Name 'TestFile' -Value "Test-Unit_$($Timestamp).xml"
 
     # Script Analyzer
-    [ValidateSet('Error', 'Warning', 'Any', 'None')]
-    $ScriptAnalysisFailBuildOnSeverityLevel = 'Error'
-    $ScriptAnalyzerSettingsPath = "$ProjectRoot/Build/PSScriptAnalyzerSettings.psd1"
+    # Valid values: 'Error', 'Warning', 'Any', 'None'.
+    Set-Variable -Name 'ScriptAnalysisFailBuildOnSeverityLevel' -Value 'Error'
+    Set-Variable -Name 'ScriptAnalyzerSettingsPath' -Value "$ProjectRoot/Build/PSScriptAnalyzerSettings.psd1"
 
     # Build
-    $ArtifactFolder = Join-Path -Path $ProjectRoot -ChildPath 'Artifacts'
+    Set-Variable -Name 'ArtifactFolder' -Value (Join-Path -Path $ProjectRoot -ChildPath 'Artifacts')
 
     # Staging
-    $StagingFolder = Join-Path -Path $ProjectRoot -ChildPath 'Staging'
-    $StagingModulePath = Join-Path -Path $StagingFolder -ChildPath $env:BHProjectName
-    #$StagingModulePath = Join-Path -Path $StagingFolder -ChildPath $ProjectName
-    $StagingModuleManifestPath = Join-Path -Path $StagingModulePath -ChildPath "$($env:BHProjectName).psd1"
-    #$StagingModuleManifestPath = Join-Path -Path $StagingModulePath -ChildPath "$($ProjectName).psd1"
+    Set-Variable -Name 'StagingFolder' -Value (Join-Path -Path $ProjectRoot -ChildPath 'Staging')
+    Set-Variable -Name 'StagingModulePath' -Value (Join-Path -Path $StagingFolder -ChildPath $env:BHProjectName)
+    Set-Variable -Name 'StagingModuleManifestPath' -Value (Join-Path -Path $StagingModulePath -ChildPath "$($env:BHProjectName).psd1")
 }
 
 # Define top-level tasks
@@ -58,8 +60,13 @@ Task 'Setup' -depends 'Init' {
     }
 }
 
-# Create a single .psm1 module file containing all functions
-# Copy new module and other supporting files to Staging folder
+# Stage the module layout for packaging.
+# Copies the public functions, manifest, root module, README, and (when
+# present) private helpers into $StagingModulePath. The module is shipped
+# as the original multi-file layout rather than being combined into a
+# single .psm1 - the loader in PS.SSL.psm1 dot-sources each file at
+# import time, which keeps file-level debugger breakpoints and stack
+# traces meaningful for consumers.
 Task 'CombineFunctionsAndStage' -depends 'Setup' {
     $lines
 
@@ -67,15 +74,7 @@ Task 'CombineFunctionsAndStage' -depends 'Setup' {
     New-Item -Path $StagingFolder -ItemType 'Directory' -Force | Out-String | Write-Verbose
     New-Item -Path $StagingModulePath -ItemType 'Directory' -Force | Out-String | Write-Verbose
 
-    # Get public and private function files
-    #$publicFunctions = @( Get-ChildItem -Path "$env:BHModulePath\Public\*.ps1" -Recurse -ErrorAction 'SilentlyContinue' )
-    #$privateFunctions = @( Get-ChildItem -Path "$env:BHModulePath\Private\*.ps1" -Recurse -ErrorAction 'SilentlyContinue' )
-
-    # Combine functions into a single .psm1 module
-    #$combinedModulePath = Join-Path -Path $StagingModulePath -ChildPath "$($env:BHProjectName).psm1"
-    #@($publicFunctions + $privateFunctions) | Get-Content | Add-Content -Path $combinedModulePath
-
-    # Copy other required folders and files.
+    # Copy required folders and files.
     # 'Private' is optional (no private helpers yet) so it is skipped when
     # absent. All other entries are required; an empty required directory is
     # treated as a build failure because it usually means files were lost or a
@@ -102,9 +101,6 @@ Task 'CombineFunctionsAndStage' -depends 'Setup' {
 
     $pathsToCopy = $requiredPaths + ($optionalPaths | Where-Object { Test-Path -Path $_ })
     Copy-Item -Path $pathsToCopy -Destination $StagingModulePath -Recurse
-
-    # Copy existing manifest
-    #Copy-Item -Path $env:BHPSModuleManifest -Destination $StagingModulePath -Recurse
 }
 
 # Import new module
@@ -169,8 +165,6 @@ Task 'Test' -depends 'ImportStagingModule' {
 
     $TestResults = Invoke-Pester -Configuration $PesterConfig
 
-    #$TestResults = Invoke-Pester -Script $TestScripts -PassThru -OutputFormat 'NUnitXml' -OutputFile $TestFilePath -PesterOption @{IncludeVSCodeMarker = $true }
-
     # Fail build if any tests fail
     if ($TestResults.FailedCount -gt 0) {
         Write-Error "Failed '$($TestResults.FailedCount)' tests, build failed"
@@ -199,7 +193,7 @@ Task 'CreateBuildArtifact' -depends 'Init' {
     try {
         $releaseFilename = "$($env:BHProjectName)-v$($manifestVersion.ToString()).zip"
         $releasePath = Join-Path -Path $ArtifactFolder -ChildPath $releaseFilename
-        Write-Output "Creating release artifact [$releasePath] using manifest version [$manifestVersion]" -ForegroundColor 'Yellow'
+        Write-Output "Creating release artifact [$releasePath] using manifest version [$manifestVersion]"
         Compress-Archive -Path "$StagingFolder/*" -DestinationPath $releasePath -Force -Verbose -ErrorAction 'Stop'
     }
     catch {

--- a/Build/build.psake.ps1
+++ b/Build/build.psake.ps1
@@ -75,14 +75,16 @@ Task 'CombineFunctionsAndStage' -depends 'Setup' {
     #$combinedModulePath = Join-Path -Path $StagingModulePath -ChildPath "$($env:BHProjectName).psm1"
     #@($publicFunctions + $privateFunctions) | Get-Content | Add-Content -Path $combinedModulePath
 
-    # Copy other required folders and files
+    # Copy other required folders and files. 'Private' is optional and may not
+    # exist when there are no private helpers; filter to existing paths so the
+    # build does not fail in that case.
     $pathsToCopy = @(
         Join-Path -Path $ProjectRoot -ChildPath 'Private'
         Join-Path -Path $ProjectRoot -ChildPath 'Public'
         Join-Path -Path $ProjectRoot -ChildPath 'README.md'
         Join-Path -Path $ProjectRoot -ChildPath ($env:BHProjectName + '.psd1')
         Join-Path -Path $ProjectRoot -ChildPath ($env:BHProjectName + '.psm1')
-    )
+    ) | Where-Object { Test-Path -Path $_ }
     Copy-Item -Path $pathsToCopy -Destination $StagingModulePath -Recurse
 
     # Copy existing manifest

--- a/Build/build.psake.ps1
+++ b/Build/build.psake.ps1
@@ -130,7 +130,7 @@ Task 'Analyze' -depends 'ImportStagingModule' {
         }
         'Error' {
             Assert -conditionToCheck (
-                ($Results | Where-Object 'Severity' -EQ 'Error').Count -eq 0
+                ($Results | Where-Object 'Severity' -eq 'Error').Count -eq 0
             ) -failureMessage 'One or more ScriptAnalyzer errors were found. Build cannot continue!'
         }
         'Warning' {

--- a/Build/build.psake.ps1
+++ b/Build/build.psake.ps1
@@ -75,16 +75,32 @@ Task 'CombineFunctionsAndStage' -depends 'Setup' {
     #$combinedModulePath = Join-Path -Path $StagingModulePath -ChildPath "$($env:BHProjectName).psm1"
     #@($publicFunctions + $privateFunctions) | Get-Content | Add-Content -Path $combinedModulePath
 
-    # Copy other required folders and files. 'Private' is optional and may not
-    # exist when there are no private helpers; filter to existing paths so the
-    # build does not fail in that case.
-    $pathsToCopy = @(
-        Join-Path -Path $ProjectRoot -ChildPath 'Private'
+    # Copy other required folders and files.
+    # 'Private' is optional (no private helpers yet) so it is skipped when
+    # absent. All other entries are required; an empty required directory is
+    # treated as a build failure because it usually means files were lost or a
+    # checkout went wrong.
+    $requiredPaths = @(
         Join-Path -Path $ProjectRoot -ChildPath 'Public'
         Join-Path -Path $ProjectRoot -ChildPath 'README.md'
         Join-Path -Path $ProjectRoot -ChildPath ($env:BHProjectName + '.psd1')
         Join-Path -Path $ProjectRoot -ChildPath ($env:BHProjectName + '.psm1')
-    ) | Where-Object { Test-Path -Path $_ }
+    )
+    $optionalPaths = @(
+        Join-Path -Path $ProjectRoot -ChildPath 'Private'
+    )
+
+    foreach ($p in $requiredPaths) {
+        if (-not (Test-Path -Path $p)) {
+            throw "Required build input not found: $p"
+        }
+        if ((Test-Path -Path $p -PathType 'Container') -and
+            -not (Get-ChildItem -Path $p -File -Recurse -ErrorAction 'SilentlyContinue')) {
+            throw "Required build input directory is empty: $p"
+        }
+    }
+
+    $pathsToCopy = $requiredPaths + ($optionalPaths | Where-Object { Test-Path -Path $_ })
     Copy-Item -Path $pathsToCopy -Destination $StagingModulePath -Recurse
 
     # Copy existing manifest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ function Verb-Noun {
         [string] $ParameterName
     )
     Begin {
-        Write-Verbose -Message 'Starting Verb-Noun'
+        Write-Verbose -Message "Starting $($MyInvocation.Mycommand)"
     }
     Process {
         # Function logic here

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,30 +21,48 @@ To propose changes to the existing functions or the creation of a new one, the p
 
 ### Content
 
-The intended purpose of the functions in this module are internal functionality within the secure boundaries, specfically within virtual machines. There should be no dependency on outside libraries.
+The intended purpose of the functions in this module are internal functionality within the secure boundaries, specifically within virtual machines. There should be no dependency on outside libraries.
 
 ### Structure
 
-- Start with this general structure
+Start with this general structure:
 
-```pwsh
-function <FunctionName> {
+```powershell
+function Verb-Noun {
     <#
     .SYNOPSIS
-        
+        Brief one-liner describing what the function does.
     .DESCRIPTION
-       
+        Detailed explanation of the function's behavior, design decisions, or constraints.
+    .PARAMETER ParameterName
+        Description of the parameter. One-liner minimum, expand for complex parameters.
     .INPUTS
-        
+        Type accepted via pipeline (e.g., System.String, None).
     .OUTPUTS
-        
+        Type returned (e.g., System.IO.FileInfo, System.Boolean, PSCustomObject).
     .EXAMPLE
-        
+        PS C:\> Verb-Noun -ParameterName Value
+        Description of what this example demonstrates.
     .NOTES
+        Status: <Stable|Beta|Experimental|Deprecated>
+        References:
+        https://example.com/relevant-documentation
     #>
-
     [CmdletBinding()]
-    Param()
+    Param(
+        [Parameter(Mandatory, ValueFromPipeline)]
+        [ValidateNotNullOrEmpty()]
+        [string] $ParameterName
+    )
+    Begin {
+        Write-Verbose -Message 'Starting Verb-Noun'
+    }
+    Process {
+        # Function logic here
+    }
+    End {
+        # Cleanup or final output
+    }
 }
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,8 +83,9 @@ Follow these steps:
 Ensure your changes are passing PSScriptAnalyzer and Pester tests.
 
 ```pwsh
-  ./Build/build.ps1 -ResolveDependency -TaskList Test # run pester
-  ./Build/build.ps1 -ResolveDependency -TaskList Analyze # run psscriptanalyzer
+./Build/build.ps1 -ResolveDependency -TaskList Test # run pester
+./Build/build.ps1 -ResolveDependency -TaskList Analyze # run psscriptanalyzer
+./Build/build.ps1 -TaskList Cleanup # remove the Artifacts and Staging folders created by Test/Analyze
 ```
 
 ## Release

--- a/PS.SSL.psd1
+++ b/PS.SSL.psd1
@@ -74,6 +74,7 @@
         'Export-PFX'
         'Get-CertificateData'
         'Get-CSRData'
+        'Get-CSRTemplate'
         'Get-RemoteSSLCertificate'
         'New-CertificateSigningRequest'
         'New-SelfSignedCertificate'
@@ -87,9 +88,7 @@
     CmdletsToExport   = @()
 
     # Variables to export from this module
-    VariablesToExport = @(
-        'CSR_Template'
-    )
+    VariablesToExport = @()
 
     # Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
     AliasesToExport   = @(

--- a/PS.SSL.psd1
+++ b/PS.SSL.psd1
@@ -9,7 +9,7 @@
     RootModule        = 'PS.SSL.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '0.2.8'
+    ModuleVersion     = '0.3.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/PS.SSL.psd1
+++ b/PS.SSL.psd1
@@ -30,7 +30,7 @@
     Description       = 'Module for creating SSL certificate signing requests'
 
     # Minimum version of the PowerShell engine required by this module
-    PowerShellVersion = '5.1'
+    PowerShellVersion = '7.0'
 
     # Name of the PowerShell host required by this module
     # PowerShellHostName = ''

--- a/PS.SSL.psm1
+++ b/PS.SSL.psm1
@@ -24,8 +24,13 @@ if ($IsMacOS -or $IsLinux) {
 }
 
 # IMPORT ALL FUNCTIONS
+# 'Private' is optional and may be absent (no private helpers). Skip missing
+# directories rather than letting Get-ChildItem throw on Linux/macOS where the
+# wildcard path is evaluated more strictly.
 foreach ( $directory in @('Public', 'Private') ) {
-    foreach ( $fn in (Get-ChildItem -Path "$PSScriptRoot\$directory\*.ps1") ) { . $fn.FullName }
+    $dirPath = Join-Path -Path $PSScriptRoot -ChildPath $directory
+    if (-not (Test-Path -Path $dirPath -PathType Container)) { continue }
+    foreach ( $fn in (Get-ChildItem -Path $dirPath -Filter '*.ps1' -File) ) { . $fn.FullName }
 }
 
 # VARIABLES

--- a/PS.SSL.psm1
+++ b/PS.SSL.psm1
@@ -33,31 +33,7 @@ foreach ( $directory in @('Public', 'Private') ) {
     foreach ( $fn in (Get-ChildItem -Path $dirPath -Filter '*.ps1' -File) ) { . $fn.FullName }
 }
 
-# VARIABLES
-New-Variable -Name 'CSR_Template' -Option ReadOnly -Value @(
-    '[req]'
-    'distinguished_name = req_distinguished_name'
-    'req_extensions = v3_req'
-    'default_bits = 4096'
-    'default_md = sha256'
-    'encrypt_key = no'
-    'prompt = no'
-    '[req_distinguished_name]'
-    'C = #C#'
-    'ST = #ST#'
-    'L = #L#'
-    'O = #O#'
-    'OU = #OU#'
-    'emailAddress = "#E#"'
-    'CN = #CN#'
-    '[v3_req]'
-    'keyUsage = keyEncipherment, dataEncipherment'
-    'extendedKeyUsage = serverAuth'
-    'subjectAltName = @alt_names'
-    '[alt_names]'
-)
-
 # EXPORT MEMBERS
 # THESE ARE SPECIFIED IN THE MODULE MANIFEST AND THEREFORE DON'T NEED TO BE LISTED HERE
 #Export-ModuleMember -Function *
-Export-ModuleMember -Variable 'CSR_Template' -Alias 'New-CSR'
+Export-ModuleMember -Alias 'New-CSR'

--- a/PS.SSL.psm1
+++ b/PS.SSL.psm1
@@ -5,7 +5,7 @@
 # ==============================================================================
 
 # CHECK FOR PLATFORM
-if ($IsWindows -or ($null -EQ $IsWindows)) {
+if ($IsWindows -or ($null -eq $IsWindows)) {
 
     # CHECK FOR OPENSSL
     if ($env:Path -notmatch 'openssl') {

--- a/Private/Build-CsrConfig.ps1
+++ b/Private/Build-CsrConfig.ps1
@@ -1,0 +1,128 @@
+function Build-CsrConfig {
+    <#
+    .SYNOPSIS
+        Render the module's CSR_Template into an openssl req config file.
+    .DESCRIPTION
+        Internal helper shared by New-CertificateSigningRequest and
+        New-SelfSignedCertificate. Takes the same subject fields the public
+        functions accept, drops the template lines whose tokens were not
+        supplied, applies any Subject Alternative Names, performs token
+        substitution, and writes the result to -OutputPath.
+
+        The rendered .conf is intentionally preserved on disk (next to the
+        cert / CSR / key it produced) so callers have a reproducible record
+        of the inputs used to generate the request.
+    .PARAMETER OutputPath
+        Full path (including filename) where the rendered .conf will be
+        written. The caller chooses the path; the helper does not pick the
+        directory or filename so the public functions remain in control of
+        their artifact-naming convention.
+    .PARAMETER CommonName
+        Common Name (CN). Always required because CN has no fallback line
+        in the template - it must be substituted, not removed.
+    .PARAMETER Country
+        Country Name (C). Optional - omitted callers get the C = line removed.
+    .PARAMETER State
+        State or Province Name (ST). Optional.
+    .PARAMETER Locality
+        Locality Name (L). Optional.
+    .PARAMETER Organization
+        Organization Name (O). Optional.
+    .PARAMETER OrganizationalUnit
+        Organizational Unit Name (OU). Optional.
+    .PARAMETER Email
+        Email address. Optional.
+    .PARAMETER SubjectAlternativeName
+        Subject Alternative Name (SAN) entries. When omitted, the [alt_names]
+        section and the subjectAltName = @alt_names directive are stripped.
+    .INPUTS
+        None.
+    .OUTPUTS
+        None. Writes the rendered config to -OutputPath as a side effect.
+    .EXAMPLE
+        PS C:\> Build-CsrConfig -CommonName www.example.com -OutputPath C:\out\www.example.com.conf -Organization Contoso
+    .NOTES
+        Name:      Build-CsrConfig
+        Author:    Justin Johns
+        - Reads the module-scoped $CSR_Template variable defined in PS.SSL.psm1.
+        - The token-substitution behavior is preserved verbatim from the
+          original inline implementations in the two public callers, so this
+          helper is a refactor with no semantic change.
+    #>
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory)]
+        [System.String] $OutputPath,
+
+        [Parameter(Mandatory)]
+        [System.String] $CommonName,
+
+        [Parameter()]
+        [System.String] $Country,
+
+        [Parameter()]
+        [System.String] $State,
+
+        [Parameter()]
+        [System.String] $Locality,
+
+        [Parameter()]
+        [System.String] $Organization,
+
+        [Parameter()]
+        [System.String] $OrganizationalUnit,
+
+        [Parameter()]
+        [System.String] $Email,
+
+        [Parameter()]
+        [System.String[]] $SubjectAlternativeName
+    )
+    Process {
+        # CREATE NEW LIST
+        $template = [System.Collections.ArrayList]::new()
+
+        # ADD TEMPLATE TO LIST
+        $template.AddRange($CSR_Template)
+
+        # ADD SUBJECT ALTERNATIVE NAMES TO LIST
+        if ($PSBoundParameters.ContainsKey('SubjectAlternativeName')) {
+            # EVALUATE EACH SAN IN ARRAY
+            for ($i = 1; $i -lt ($SubjectAlternativeName.Count + 1); $i++) {
+                # ADD SAN TO END OF COLLECTION
+                $template.Add(('DNS.{0} = {1}' -f $i, $SubjectAlternativeName[$i - 1])) | Out-Null
+            }
+        }
+
+        # SET REPLACEMENT TOKENS
+        $tokenList = @{ CN = $CommonName }
+        if ($PSBoundParameters.ContainsKey('Country')) { $tokenList.Add('C', $Country) } else { $template.Remove('C = #C#') }
+        if ($PSBoundParameters.ContainsKey('State')) { $tokenList.Add('ST', $State) } else { $template.Remove('ST = #ST#') }
+        if ($PSBoundParameters.ContainsKey('Locality')) { $tokenList.Add('L', $Locality) } else { $template.Remove('L = #L#') }
+        if ($PSBoundParameters.ContainsKey('Organization')) { $tokenList.Add('O', $Organization) } else { $template.Remove('O = #O#') }
+        if ($PSBoundParameters.ContainsKey('OrganizationalUnit')) { $tokenList.Add('OU', $OrganizationalUnit) } else { $template.Remove('OU = #OU#') }
+        if ($PSBoundParameters.ContainsKey('Email')) { $tokenList.Add('E', $Email) } else { $template.Remove('emailAddress = "#E#"') }
+
+        # REMOVE SAN FROM TEMPLATE IF NOT PROVIDED
+        if (-Not $PSBoundParameters.ContainsKey('SubjectAlternativeName')) {
+            $template.Remove('[alt_names]')
+            $template.Remove('subjectAltName = @alt_names')
+        }
+
+        # REPLACE TOKENS IN TEMPLATE
+        foreach ($token in $tokenList.GetEnumerator()) {
+            $pattern = '#{0}#' -f $token.key
+            $template = $template -replace $pattern, $token.Value
+        }
+
+        # SHOW TEMPLATE
+        Write-Verbose -Message ("`n" + ($template -join "`n"))
+
+        # Preserved intentionally as a record of the settings used to
+        # generate the sibling .csr / .key / .pem artifacts. Do not
+        # treat this file as a temp file - callers depend on it staying.
+        Set-Content -Path $OutputPath -Value $template -Confirm:$false
+
+        Write-Verbose -Message ('Template file path: [{0}]' -f $OutputPath)
+    }
+}

--- a/Private/Build-CsrConfig.ps1
+++ b/Private/Build-CsrConfig.ps1
@@ -1,7 +1,7 @@
 function Build-CsrConfig {
     <#
     .SYNOPSIS
-        Render the module's CSR_Template into an openssl req config file.
+        Render the module's CSR template into an openssl req config file.
     .DESCRIPTION
         Internal helper shared by New-CertificateSigningRequest and
         New-SelfSignedCertificate. Takes the same subject fields the public
@@ -43,7 +43,8 @@ function Build-CsrConfig {
         PS C:\> Build-CsrConfig -CommonName www.example.com -OutputPath C:\out\www.example.com.conf -Organization Contoso
     .NOTES
         Status: Stable
-        - Reads the module-scoped $CSR_Template variable defined in PS.SSL.psm1.
+        - Reads the canonical template via Public/Get-CSRTemplate.ps1 so the
+          template definition lives in exactly one place.
         - The token-substitution behavior is preserved verbatim from the
           original inline implementations in the two public callers, so this
           helper is a refactor with no semantic change.
@@ -82,7 +83,7 @@ function Build-CsrConfig {
         $template = [System.Collections.ArrayList]::new()
 
         # ADD TEMPLATE TO LIST
-        $template.AddRange($CSR_Template)
+        $template.AddRange((Get-CSRTemplate))
 
         # ADD SUBJECT ALTERNATIVE NAMES TO LIST
         if ($PSBoundParameters.ContainsKey('SubjectAlternativeName')) {

--- a/Private/Build-CsrConfig.ps1
+++ b/Private/Build-CsrConfig.ps1
@@ -42,8 +42,7 @@ function Build-CsrConfig {
     .EXAMPLE
         PS C:\> Build-CsrConfig -CommonName www.example.com -OutputPath C:\out\www.example.com.conf -Organization Contoso
     .NOTES
-        Name:      Build-CsrConfig
-        Author:    Justin Johns
+        Status: Stable
         - Reads the module-scoped $CSR_Template variable defined in PS.SSL.psm1.
         - The token-substitution behavior is preserved verbatim from the
           original inline implementations in the two public callers, so this

--- a/Private/Initialize-OutputDirectory.ps1
+++ b/Private/Initialize-OutputDirectory.ps1
@@ -1,0 +1,48 @@
+function Initialize-OutputDirectory {
+    <#
+    .SYNOPSIS
+        Ensure an output directory exists, creating it if necessary.
+    .DESCRIPTION
+        Internal helper shared by every public function that writes
+        artifacts to disk. Centralizes the previously copy-pasted
+        "if (-not (Test-Path ...)) { New-Item ... }" snippet so the
+        behavior (path testing, creation, verbose logging, error wording)
+        is identical across the module.
+
+        Designed to be paired with the matching `[ValidateScript()]`
+        attribute on the public -OutputDirectory parameter: validation
+        confirms the parent exists; this helper materializes the leaf.
+    .PARAMETER Path
+        Directory path to ensure exists. May be absolute or relative.
+        If the path already exists and is a directory, the helper is a
+        no-op. If it exists and is a file, a terminating error is raised.
+        If it does not exist, the directory is created.
+    .INPUTS
+        None.
+    .OUTPUTS
+        None. Creates the directory as a side effect.
+    .EXAMPLE
+        PS C:\> Initialize-OutputDirectory -Path "$HOME\Desktop\out"
+    .NOTES
+        Name:      Initialize-OutputDirectory
+        Author:    Justin Johns
+        - Uses `Write-Error -ErrorAction Stop` rather than `throw` to
+          stay consistent with the module-wide error-emission convention.
+    #>
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [System.String] $Path
+    )
+    Process {
+        if (Test-Path -Path $Path -PathType Container) { return }
+
+        if (Test-Path -Path $Path -PathType Leaf) {
+            Write-Error -Message "Output directory path '$Path' exists but is a file, not a directory." -ErrorAction Stop
+        }
+
+        Write-Verbose -Message ('Creating output directory: {0}' -f $Path)
+        New-Item -Path $Path -ItemType Directory -Force | Out-Null
+    }
+}

--- a/Private/Initialize-OutputDirectory.ps1
+++ b/Private/Initialize-OutputDirectory.ps1
@@ -24,8 +24,7 @@ function Initialize-OutputDirectory {
     .EXAMPLE
         PS C:\> Initialize-OutputDirectory -Path "$HOME\Desktop\out"
     .NOTES
-        Name:      Initialize-OutputDirectory
-        Author:    Justin Johns
+        Status: Stable
         - Uses `Write-Error -ErrorAction Stop` rather than `throw` to
           stay consistent with the module-wide error-emission convention.
     #>

--- a/Private/Invoke-OpenSsl.ps1
+++ b/Private/Invoke-OpenSsl.ps1
@@ -62,6 +62,7 @@ function Invoke-OpenSsl {
         $startInfo.FileName               = 'openssl'
         $startInfo.RedirectStandardOutput = $true
         $startInfo.RedirectStandardError  = $true
+        $startInfo.RedirectStandardInput  = $true
         $startInfo.UseShellExecute        = $false
         $startInfo.CreateNoWindow         = $true
 
@@ -76,6 +77,22 @@ function Invoke-OpenSsl {
         $process.StartInfo = $startInfo
         try {
             [System.Void] $process.Start()
+
+            # CLOSE STDIN IMMEDIATELY SO COMMANDS THAT WOULD OTHERWISE BLOCK
+            # WAITING FOR INPUT EXIT CLEANLY. Two cases this addresses:
+            #   1. `openssl s_client` after a successful handshake reads from
+            #      stdin and stays open until EOF; without this close the
+            #      Test-Protocol / Test-Cipher Supported=true path would hang.
+            #   2. `openssl req -new` with a -config file that omits
+            #      `prompt = no` would otherwise prompt for DN fields on the
+            #      console - turning an unattended call into an interactive
+            #      hang. With stdin closed it fails fast with a clear stderr
+            #      ("No value provided for Subject Attribute CN") which the
+            #      helper surfaces in the terminating error message.
+            # No current module call site feeds stdin, so unconditional close
+            # is safe. If a future caller needs to pipe data in, add an opt-out
+            # switch rather than removing this line.
+            $process.StandardInput.Close()
 
             # READ BOTH STREAMS BEFORE WaitForExit() TO AVOID DEADLOCKING ON
             # COMMANDS THAT FILL EITHER PIPE'S OS BUFFER (typical limit ~4KB

--- a/Private/Invoke-OpenSsl.ps1
+++ b/Private/Invoke-OpenSsl.ps1
@@ -36,11 +36,8 @@ function Invoke-OpenSsl {
         PS C:\> if ($r.ExitCode -eq 0) { 'supported' } else { 'not supported' }
         Use -IgnoreExitCode for probing scenarios where a non-zero exit is meaningful, not fatal.
     .NOTES
-        Name:      Invoke-OpenSsl
-        Author:    Justin Johns
-        Version:   0.1.0 | Last Edit: 2026-05-22
-        - Version history is captured in repository commit history
-        Internal helper. Not exported from the module.
+        Status: Stable
+        - Internal helper. Not exported from the module.
     #>
     [CmdletBinding()]
     [OutputType([System.Management.Automation.PSCustomObject])]

--- a/Private/Invoke-OpenSsl.ps1
+++ b/Private/Invoke-OpenSsl.ps1
@@ -47,33 +47,57 @@ function Invoke-OpenSsl {
     Begin {
         Write-Verbose -Message "Starting $($MyInvocation.MyCommand)"
 
+        # FAIL FAST IF OPENSSL IS NOT ON PATH. THIS IS A TERMINATING ERROR
+        # SO CALLERS DON'T NEED TO RE-CHECK; SURFACES A CLEAR DIAGNOSTIC
+        # INSTEAD OF A CRYPTIC "FILE NOT FOUND" FROM Process.Start().
         if (-not (Get-Command -Name 'openssl' -CommandType Application -ErrorAction SilentlyContinue)) {
             Write-Error -Message "'openssl' was not found on PATH." -Category ObjectNotFound -ErrorAction Stop
         }
     }
     Process {
+        # BUILD THE PROCESS START INFO. UseShellExecute=$false IS REQUIRED
+        # IN ORDER TO REDIRECT STDOUT/STDERR; CreateNoWindow=$true SUPPRESSES
+        # THE TRANSIENT CONSOLE WINDOW THAT OTHERWISE FLASHES ON WINDOWS.
         $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
         $startInfo.FileName               = 'openssl'
         $startInfo.RedirectStandardOutput = $true
         $startInfo.RedirectStandardError  = $true
         $startInfo.UseShellExecute        = $false
         $startInfo.CreateNoWindow         = $true
+
+        # POPULATE ArgumentList ONE ENTRY AT A TIME. PowerShell 7+ uses the
+        # collection form (not the legacy Arguments string), which lets the
+        # runtime handle argv quoting per-OS. Pre-joining or quoting the
+        # caller-supplied values would re-introduce the very injection and
+        # space-fragmentation bugs this helper exists to eliminate.
         foreach ($argument in $ArgumentList) { $startInfo.ArgumentList.Add($argument) }
 
         $process = [System.Diagnostics.Process]::new()
         $process.StartInfo = $startInfo
         try {
             [System.Void] $process.Start()
+
+            # READ BOTH STREAMS BEFORE WaitForExit() TO AVOID DEADLOCKING ON
+            # COMMANDS THAT FILL EITHER PIPE'S OS BUFFER (typical limit ~4KB
+            # on Windows). A WaitForExit() before draining the pipes would
+            # hang any openssl invocation that emits more than that.
             $standardOutput = $process.StandardOutput.ReadToEnd()
             $standardError  = $process.StandardError.ReadToEnd()
             $process.WaitForExit()
 
+            # ALWAYS BUILD THE RESULT OBJECT - EVEN ON FAILURE - SO THE
+            # -IgnoreExitCode PATH HAS SOMETHING TO RETURN AND THE ERROR
+            # MESSAGE BELOW CAN INCLUDE THE STDERR TEXT.
             $result = [PSCustomObject] @{
                 ExitCode = $process.ExitCode
                 StdOut   = $standardOutput
                 StdErr   = $standardError
             }
 
+            # DEFAULT BEHAVIOR: NON-ZERO EXIT IS TERMINATING. Including the
+            # trimmed stderr in the message preserves diagnostics that were
+            # previously lost by Start-Process -NoNewWindow (which silently
+            # dropped the openssl error text).
             if ($process.ExitCode -ne 0 -and -not $IgnoreExitCode) {
                 Write-Error -Message ("openssl exited with code {0}: {1}" -f $process.ExitCode, $standardError.Trim()) -Category InvalidResult -ErrorAction Stop
             }
@@ -81,6 +105,9 @@ function Invoke-OpenSsl {
             $result
         }
         finally {
+            # ALWAYS DISPOSE - Process HOLDS UNMANAGED HANDLES (pipes, the
+            # win32 process handle) THAT WILL LEAK UNTIL THE GC FINALIZER
+            # RUNS IF NOT EXPLICITLY RELEASED.
             $process.Dispose()
         }
     }

--- a/Private/Invoke-OpenSsl.ps1
+++ b/Private/Invoke-OpenSsl.ps1
@@ -16,6 +16,14 @@ function Invoke-OpenSsl {
     .PARAMETER IgnoreExitCode
         Return the result object even when openssl exits non-zero. Callers must
         inspect the ExitCode property themselves.
+    .PARAMETER EnvironmentVariable
+        Dictionary of environment variables to set on the openssl child process
+        only. Use this to hand sensitive values (e.g. PFX passwords) to openssl
+        via -passin env:VAR / -passout env:VAR instead of pass:..., which would
+        place the secret on the command line where it is visible to process
+        listings, EDR telemetry, and audit logs. SecureString values are
+        unwrapped just-in-time inside the helper. The variables are NOT
+        propagated to the parent PowerShell session.
     .INPUTS
         None.
     .OUTPUTS
@@ -42,7 +50,10 @@ function Invoke-OpenSsl {
         [System.String[]] $ArgumentList,
 
         [Parameter(HelpMessage = 'Return non-zero exits as data instead of a terminating error')]
-        [System.Management.Automation.SwitchParameter] $IgnoreExitCode
+        [System.Management.Automation.SwitchParameter] $IgnoreExitCode,
+
+        [Parameter(HelpMessage = 'Environment variables to set on the openssl child process only')]
+        [System.Collections.IDictionary] $EnvironmentVariable
     )
     Begin {
         Write-Verbose -Message "Starting $($MyInvocation.MyCommand)"
@@ -73,9 +84,42 @@ function Invoke-OpenSsl {
         # space-fragmentation bugs this helper exists to eliminate.
         foreach ($argument in $ArgumentList) { $startInfo.ArgumentList.Add($argument) }
 
-        $process = [System.Diagnostics.Process]::new()
-        $process.StartInfo = $startInfo
+        # APPLY PER-INVOCATION ENVIRONMENT VARIABLES. ProcessStartInfo.Environment
+        # is seeded from the parent's environment when first accessed; mutating
+        # it here affects ONLY the child openssl process and never the
+        # PowerShell session. This is how -passin env:VAR / -passout env:VAR
+        # receive secrets without exposing them on argv (which is readable by
+        # peer processes via Get-Process / ETW / EDR telemetry). On modern
+        # Windows a process environment is not readable by non-admin peer
+        # users, so env: is strictly better than pass: for credential handoff.
+        #
+        # SecureString values are unwrapped via SecureStringToBSTR. The BSTR
+        # is tracked in $unwrappedSecureStrings and zeroed+freed in the outer
+        # finally{} so the plaintext is wiped from unmanaged memory as soon
+        # as openssl has consumed it. The managed string stored on the
+        # ProcessStartInfo.Environment dictionary is the only remaining copy
+        # at that point; it lives until the next GC cycle.
+        $unwrappedSecureStrings = [System.Collections.Generic.List[System.IntPtr]]::new()
+        $process = $null
         try {
+            if ($PSBoundParameters.ContainsKey('EnvironmentVariable')) {
+                foreach ($entry in $EnvironmentVariable.GetEnumerator()) {
+                    $name  = [System.String] $entry.Key
+                    $value = $entry.Value
+                    if ($value -is [System.Security.SecureString]) {
+                        $bstr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($value)
+                        $unwrappedSecureStrings.Add($bstr)
+                        $startInfo.Environment[$name] = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($bstr)
+                    }
+                    else {
+                        $startInfo.Environment[$name] = [System.String] $value
+                    }
+                }
+            }
+
+            $process = [System.Diagnostics.Process]::new()
+            $process.StartInfo = $startInfo
+
             [System.Void] $process.Start()
 
             # CLOSE STDIN IMMEDIATELY SO COMMANDS THAT WOULD OTHERWISE BLOCK
@@ -122,10 +166,19 @@ function Invoke-OpenSsl {
             $result
         }
         finally {
+            # ZERO AND FREE EVERY UNWRAPPED BSTR. ZeroFreeBSTR overwrites the
+            # unmanaged buffer with zeros before releasing it so the plaintext
+            # password cannot be recovered from a process dump after this
+            # invocation returns. Done unconditionally - including on error
+            # paths - to guarantee no leak across exception boundaries.
+            foreach ($bstr in $unwrappedSecureStrings) {
+                [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
+            }
+
             # ALWAYS DISPOSE - Process HOLDS UNMANAGED HANDLES (pipes, the
             # win32 process handle) THAT WILL LEAK UNTIL THE GC FINALIZER
             # RUNS IF NOT EXPLICITLY RELEASED.
-            $process.Dispose()
+            if ($null -ne $process) { $process.Dispose() }
         }
     }
 }

--- a/Private/Invoke-OpenSsl.ps1
+++ b/Private/Invoke-OpenSsl.ps1
@@ -1,0 +1,87 @@
+function Invoke-OpenSsl {
+    <#
+    .SYNOPSIS
+        Invoke the openssl command-line tool and capture its output.
+    .DESCRIPTION
+        Centralized wrapper for openssl. Builds a System.Diagnostics.Process with
+        stdout/stderr redirected so callers receive the result in any PowerShell
+        host (including ISE, VSCode terminal, remoting sessions, and CI). On a
+        non-zero exit code the function emits a terminating error unless
+        -IgnoreExitCode is supplied (used by probing callers such as Test-Cipher
+        and Test-Protocol where a non-zero exit is an expected outcome).
+    .PARAMETER ArgumentList
+        Arguments to pass to openssl. Each element is a discrete argv entry; do
+        not pre-join into a single string and do not wrap values containing
+        spaces in quotes. Quoting is handled by ProcessStartInfo.ArgumentList.
+    .PARAMETER IgnoreExitCode
+        Return the result object even when openssl exits non-zero. Callers must
+        inspect the ExitCode property themselves.
+    .INPUTS
+        None.
+    .OUTPUTS
+        System.Management.Automation.PSCustomObject with ExitCode, StdOut, StdErr.
+    .EXAMPLE
+        PS C:\> Invoke-OpenSsl -ArgumentList 'version'
+        Runs 'openssl version' and returns a result object.
+    .EXAMPLE
+        PS C:\> $r = Invoke-OpenSsl -ArgumentList @('s_client', '-cipher', $c, '-connect', "$h`:443") -IgnoreExitCode
+        PS C:\> if ($r.ExitCode -eq 0) { 'supported' } else { 'not supported' }
+        Use -IgnoreExitCode for probing scenarios where a non-zero exit is meaningful, not fatal.
+    .NOTES
+        Name:      Invoke-OpenSsl
+        Author:    Justin Johns
+        Version:   0.1.0 | Last Edit: 2026-05-22
+        - Version history is captured in repository commit history
+        Internal helper. Not exported from the module.
+    #>
+    [CmdletBinding()]
+    [OutputType([System.Management.Automation.PSCustomObject])]
+    Param(
+        [Parameter(Mandatory, Position = 0, HelpMessage = 'Arguments to pass to openssl (argv-style array)')]
+        [ValidateNotNullOrEmpty()]
+        [System.String[]] $ArgumentList,
+
+        [Parameter(HelpMessage = 'Return non-zero exits as data instead of a terminating error')]
+        [System.Management.Automation.SwitchParameter] $IgnoreExitCode
+    )
+    Begin {
+        Write-Verbose -Message "Starting $($MyInvocation.MyCommand)"
+
+        if (-not (Get-Command -Name 'openssl' -CommandType Application -ErrorAction SilentlyContinue)) {
+            Write-Error -Message "'openssl' was not found on PATH." -Category ObjectNotFound -ErrorAction Stop
+        }
+    }
+    Process {
+        $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+        $startInfo.FileName               = 'openssl'
+        $startInfo.RedirectStandardOutput = $true
+        $startInfo.RedirectStandardError  = $true
+        $startInfo.UseShellExecute        = $false
+        $startInfo.CreateNoWindow         = $true
+        foreach ($argument in $ArgumentList) { $startInfo.ArgumentList.Add($argument) }
+
+        $process = [System.Diagnostics.Process]::new()
+        $process.StartInfo = $startInfo
+        try {
+            [System.Void] $process.Start()
+            $standardOutput = $process.StandardOutput.ReadToEnd()
+            $standardError  = $process.StandardError.ReadToEnd()
+            $process.WaitForExit()
+
+            $result = [PSCustomObject] @{
+                ExitCode = $process.ExitCode
+                StdOut   = $standardOutput
+                StdErr   = $standardError
+            }
+
+            if ($process.ExitCode -ne 0 -and -not $IgnoreExitCode) {
+                Write-Error -Message ("openssl exited with code {0}: {1}" -f $process.ExitCode, $standardError.Trim()) -Category InvalidResult -ErrorAction Stop
+            }
+
+            $result
+        }
+        finally {
+            $process.Dispose()
+        }
+    }
+}

--- a/Private/Test-OutputDirectoryPath.ps1
+++ b/Private/Test-OutputDirectoryPath.ps1
@@ -32,8 +32,7 @@ function Test-OutputDirectoryPath {
         PS C:\> [ValidateScript({ Test-OutputDirectoryPath $_ })]
         PS C:\> [string] $OutputDirectory
     .NOTES
-        Name:      Test-OutputDirectoryPath
-        Author:    Justin Johns
+        Status: Stable
         - Paired with Private/Initialize-OutputDirectory.ps1, which
           handles the creation half once binding succeeds.
         - Uses `Write-Error -ErrorAction Stop` rather than `throw` to

--- a/Private/Test-OutputDirectoryPath.ps1
+++ b/Private/Test-OutputDirectoryPath.ps1
@@ -1,0 +1,67 @@
+function Test-OutputDirectoryPath {
+    <#
+    .SYNOPSIS
+        Validate a candidate -OutputDirectory value.
+    .DESCRIPTION
+        Internal helper used by the `[ValidateScript({ ... })]` attribute on
+        every public function's -OutputDirectory parameter. Centralizes the
+        previously copy-pasted validation block so behavior and error wording
+        stay identical across the module.
+
+        Semantics:
+          * The supplied path must not already exist as a file.
+          * The parent directory must exist (so Initialize-OutputDirectory
+            can safely materialize the leaf). A single-segment relative
+            path (e.g. 'out') is treated as having parent '.' so it
+            validates correctly when CWD is a real directory.
+
+        On failure a terminating error is raised via
+        `Write-Error -ErrorAction Stop`, which is what `ValidateScript`
+        surfaces back to the parameter binder as a validation failure
+        with a useful message. On success `$true` is returned so the
+        attribute is happy.
+    .PARAMETER Path
+        Candidate output-directory path. May be absolute or relative,
+        may or may not exist yet.
+    .INPUTS
+        None.
+    .OUTPUTS
+        System.Boolean. Always `$true` when the function returns
+        normally; otherwise a terminating error is thrown.
+    .EXAMPLE
+        PS C:\> [ValidateScript({ Test-OutputDirectoryPath $_ })]
+        PS C:\> [string] $OutputDirectory
+    .NOTES
+        Name:      Test-OutputDirectoryPath
+        Author:    Justin Johns
+        - Paired with Private/Initialize-OutputDirectory.ps1, which
+          handles the creation half once binding succeeds.
+        - Uses `Write-Error -ErrorAction Stop` rather than `throw` to
+          stay consistent with the module-wide error-emission convention.
+    #>
+    [CmdletBinding()]
+    [OutputType([System.Boolean])]
+    Param(
+        [Parameter(Mandatory, Position = 0)]
+        [AllowEmptyString()]
+        [System.String] $Path
+    )
+    Process {
+        if ([string]::IsNullOrWhiteSpace($Path)) {
+            Write-Error -Message 'OutputDirectory cannot be empty.' -ErrorAction Stop
+        }
+
+        if (Test-Path -Path $Path -PathType Leaf) {
+            Write-Error -Message "OutputDirectory '$Path' exists but is a file, not a directory." -ErrorAction Stop
+        }
+
+        $parent = Split-Path -Path $Path -Parent
+        if ([string]::IsNullOrEmpty($parent)) { $parent = '.' }
+
+        if (-not (Test-Path -Path $parent -PathType Container)) {
+            Write-Error -Message "Parent of OutputDirectory does not exist: $parent" -ErrorAction Stop
+        }
+
+        $true
+    }
+}

--- a/Private/temp.txt
+++ b/Private/temp.txt
@@ -1,1 +1,0 @@
-This is a place holder

--- a/Public/ConvertFrom-PKCS7.ps1
+++ b/Public/ConvertFrom-PKCS7.ps1
@@ -16,7 +16,7 @@ function ConvertFrom-PKCS7 {
         PS C:\> ConvertFrom-PKCS7 -Path .\myCert.cer -OutputDirectory .\newFolder
         Converts a PKCS7 formatted certificate to non-PKCS7 format with .crt extension
     .NOTES
-        General notes
+        Status: Stable
     #>
     [CmdletBinding()]
     Param(

--- a/Public/ConvertFrom-PKCS7.ps1
+++ b/Public/ConvertFrom-PKCS7.ps1
@@ -25,17 +25,7 @@ function ConvertFrom-PKCS7 {
         [System.String] $Path,
 
         [Parameter(HelpMessage = 'Output directory for generated files')]
-        [ValidateScript({
-                if (Test-Path -Path $_ -PathType Leaf) {
-                    Write-Error -Message "OutputDirectory '$_' exists but is a file, not a directory." -ErrorAction Stop
-                }
-                $parent = Split-Path -Path $_ -Parent
-                if ([string]::IsNullOrEmpty($parent)) { $parent = '.' }
-                if (-not (Test-Path -Path $parent -PathType Container)) {
-                    Write-Error -Message "Parent of OutputDirectory does not exist: $parent" -ErrorAction Stop
-                }
-                $true
-            })]
+        [ValidateScript({ Test-OutputDirectoryPath -Path $_ })]
         [System.String] $OutputDirectory = "$HOME\Desktop"
     )
     Begin {

--- a/Public/ConvertFrom-PKCS7.ps1
+++ b/Public/ConvertFrom-PKCS7.ps1
@@ -29,6 +29,8 @@ function ConvertFrom-PKCS7 {
         [System.String] $OutputDirectory = "$HOME\Desktop"
     )
     Begin {
+        Write-Verbose -Message "Starting $($MyInvocation.Mycommand)"
+
         # GET OUTPUT DIRECTORY
         Initialize-OutputDirectory -Path $OutputDirectory
 

--- a/Public/ConvertFrom-PKCS7.ps1
+++ b/Public/ConvertFrom-PKCS7.ps1
@@ -24,16 +24,23 @@ function ConvertFrom-PKCS7 {
         [ValidateScript({ Test-Path -Path $_ -PathType Leaf -Include '*.crt', '*.cer', '*.pem' })]
         [System.String] $Path,
 
-        [Parameter(HelpMessage = 'Output directory for CSR and key file')]
-        [ValidateScript({ Test-Path -Path (Split-Path -Path $_) -PathType Container })]
+        [Parameter(HelpMessage = 'Output directory for generated files')]
+        [ValidateScript({
+                if (Test-Path -Path $_ -PathType Leaf) {
+                    Write-Error -Message "OutputDirectory '$_' exists but is a file, not a directory." -ErrorAction Stop
+                }
+                $parent = Split-Path -Path $_ -Parent
+                if ([string]::IsNullOrEmpty($parent)) { $parent = '.' }
+                if (-not (Test-Path -Path $parent -PathType Container)) {
+                    Write-Error -Message "Parent of OutputDirectory does not exist: $parent" -ErrorAction Stop
+                }
+                $true
+            })]
         [System.String] $OutputDirectory = "$HOME\Desktop"
     )
     Begin {
         # GET OUTPUT DIRECTORY
-        if (-not (Test-Path -Path $OutputDirectory)) {
-            New-Item -Path $OutputDirectory -ItemType Directory
-            Write-Verbose -Message ('Created new folder: {0}' -f $OutputDirectory)
-        }
+        Initialize-OutputDirectory -Path $OutputDirectory
 
         # SET OUTPUT FILE NAME
         $name = '{0}.crt' -f (Split-Path -Path $Path -LeafBase)

--- a/Public/ConvertFrom-PKCS7.ps1
+++ b/Public/ConvertFrom-PKCS7.ps1
@@ -42,20 +42,7 @@ function ConvertFrom-PKCS7 {
     End {
         # VERIFY SIGNED CERTIFICATE
         # openssl.exe pkcs7 -in certnew.p7b -print_certs -out $newFile
-        $sslParams = @{
-            FilePath     = 'openssl' # .exe
-            ArgumentList = @(
-                'pkcs7'
-                '-in {0}' -f $Path
-                '-print_certs'
-                '-out {0}' -f (Join-Path -Path $OutputDirectory -ChildPath $name)
-            )
-            Wait         = $true
-            NoNewWindow  = $true
-            PassThru     = $true
-        }
-        $proc = Start-Process @sslParams
-
-        if ($proc.ExitCode -NE 0) { Write-Error -Message ('openssl exited with code: {0}' -f $proc.ExitCode) }
+        $outFile = Join-Path -Path $OutputDirectory -ChildPath $name
+        [System.Void] (Invoke-OpenSsl -ArgumentList @('pkcs7', '-in', $Path, '-print_certs', '-out', $outFile))
     }
 }

--- a/Public/ConvertTo-PEM.ps1
+++ b/Public/ConvertTo-PEM.ps1
@@ -4,8 +4,8 @@ function ConvertTo-PEM {
         Convert PFX/P12 file to PEM file
     .DESCRIPTION
         Convert PFX/P12 file to PEM file including private key
-    .PARAMETER PFX
-        Path to PFX file
+    .PARAMETER Path
+        Path to PFX file. Accepts the legacy alias -PFX.
     .PARAMETER OutputDirectory
         Path to plain text output directory
     .PARAMETER Password
@@ -15,7 +15,7 @@ function ConvertTo-PEM {
     .OUTPUTS
         None.
     .EXAMPLE
-        PS C:\> ConvertTo-PEM -PFX .\myCert.pfx -OutputDirectory .\newFolder -Password $pw
+        PS C:\> ConvertTo-PEM -Path .\myCert.pfx -OutputDirectory .\newFolder -Password $pw
         Converts myCert.pfx to myCert.pem exposing all certificate details in plain text
     .NOTES
         General notes
@@ -24,7 +24,8 @@ function ConvertTo-PEM {
     Param(
         [Parameter(Mandatory, HelpMessage = 'Path to PFX file')]
         [ValidateScript({ Test-Path -Path $_ -PathType Leaf -Include "*.pfx", "*.p12" })]
-        [System.String] $PFX,
+        [Alias('PFX')]
+        [System.String] $Path,
 
         [Parameter(HelpMessage = 'Output directory for PEM file')]
         [ValidateScript( { Test-Path -Path (Split-Path -Path $_) -PathType Container })]
@@ -36,7 +37,7 @@ function ConvertTo-PEM {
     )
     Begin {
         # VALIDATE PASSWORD
-        Get-PfxCertificate -FilePath $PFX -Password $Password -ErrorAction Stop | Out-Null
+        Get-PfxCertificate -FilePath $Path -Password $Password -ErrorAction Stop | Out-Null
 
         # GET OUTPUT DIRECTORY
         if (-not (Test-Path -Path $OutputDirectory)) {
@@ -45,7 +46,7 @@ function ConvertTo-PEM {
         }
 
         # SET OUTPUT FILE NAME
-        $name = '{0}.pem' -f (Split-Path -Path $PFX -LeafBase)
+        $name = '{0}.pem' -f (Split-Path -Path $Path -LeafBase)
         Write-Verbose -Message ('Set filename to: {0}' -f $name)
     }
     End {
@@ -57,7 +58,7 @@ function ConvertTo-PEM {
         # and EDR command-line telemetry.
         $outFile = Join-Path -Path $OutputDirectory -ChildPath $name
         $sslParams = @{
-            ArgumentList        = @('pkcs12', '-in', $PFX, '-out', $outFile, '-nodes', '-passin', 'env:PSSL_PASSIN')
+            ArgumentList        = @('pkcs12', '-in', $Path, '-out', $outFile, '-nodes', '-passin', 'env:PSSL_PASSIN')
             EnvironmentVariable = @{ PSSL_PASSIN = $Password }
         }
         [System.Void] (Invoke-OpenSsl @sslParams)

--- a/Public/ConvertTo-PEM.ps1
+++ b/Public/ConvertTo-PEM.ps1
@@ -27,8 +27,18 @@ function ConvertTo-PEM {
         [Alias('PFX')]
         [System.String] $Path,
 
-        [Parameter(HelpMessage = 'Output directory for PEM file')]
-        [ValidateScript( { Test-Path -Path (Split-Path -Path $_) -PathType Container })]
+        [Parameter(HelpMessage = 'Output directory for generated files')]
+        [ValidateScript({
+                if (Test-Path -Path $_ -PathType Leaf) {
+                    Write-Error -Message "OutputDirectory '$_' exists but is a file, not a directory." -ErrorAction Stop
+                }
+                $parent = Split-Path -Path $_ -Parent
+                if ([string]::IsNullOrEmpty($parent)) { $parent = '.' }
+                if (-not (Test-Path -Path $parent -PathType Container)) {
+                    Write-Error -Message "Parent of OutputDirectory does not exist: $parent" -ErrorAction Stop
+                }
+                $true
+            })]
         [System.String] $OutputDirectory = "$HOME\Desktop",
 
         [Parameter(Mandatory, HelpMessage = 'Password to PFX file')]
@@ -40,10 +50,7 @@ function ConvertTo-PEM {
         Get-PfxCertificate -FilePath $Path -Password $Password -ErrorAction Stop | Out-Null
 
         # GET OUTPUT DIRECTORY
-        if (-not (Test-Path -Path $OutputDirectory)) {
-            New-Item -Path $OutputDirectory -ItemType Directory
-            Write-Verbose -Message ('Created new folder: {0}' -f $OutputDirectory)
-        }
+        Initialize-OutputDirectory -Path $OutputDirectory
 
         # SET OUTPUT FILE NAME
         $name = '{0}.pem' -f (Split-Path -Path $Path -LeafBase)

--- a/Public/ConvertTo-PEM.ps1
+++ b/Public/ConvertTo-PEM.ps1
@@ -47,17 +47,17 @@ function ConvertTo-PEM {
         # SET OUTPUT FILE NAME
         $name = '{0}.pem' -f (Split-Path -Path $PFX -LeafBase)
         Write-Verbose -Message ('Set filename to: {0}' -f $name)
-
-        # CREATE CREDENTIAL OBJECT WITH PASSWORD
-        $creds = [System.Management.Automation.PSCredential]::new('UserName', $Password)
     }
     End {
         # VERIFY SIGNED CERTIFICATE
-        # openssl pkcs12 -in <PFX_PATH> -out <FILE.TXT> -nodes
-        # NOTE: -passin pass:... still exposes the password to process listings.
-        #       Item 2a will migrate this to -passin env:VAR using the helper.
+        # openssl pkcs12 -in <PFX_PATH> -out <FILE.TXT> -nodes -passin env:PSSL_PASSIN
+        # PASS THE PASSWORD VIA AN ENVIRONMENT VARIABLE SCOPED TO THE OPENSSL
+        # CHILD PROCESS - never on argv, never in the parent session - so it
+        # is invisible to peer-process listings, ETW process-start events,
+        # and EDR command-line telemetry.
         $outFile = Join-Path -Path $OutputDirectory -ChildPath $name
-        $passInArg = 'pass:{0}' -f $creds.GetNetworkCredential().Password
-        [System.Void] (Invoke-OpenSsl -ArgumentList @('pkcs12', '-in', $PFX, '-out', $outFile, '-nodes', '-passin', $passInArg))
+        [System.Void] (Invoke-OpenSsl `
+            -ArgumentList @('pkcs12', '-in', $PFX, '-out', $outFile, '-nodes', '-passin', 'env:PSSL_PASSIN') `
+            -EnvironmentVariable @{ PSSL_PASSIN = $Password })
     }
 }

--- a/Public/ConvertTo-PEM.ps1
+++ b/Public/ConvertTo-PEM.ps1
@@ -18,7 +18,7 @@ function ConvertTo-PEM {
         PS C:\> ConvertTo-PEM -Path .\myCert.pfx -OutputDirectory .\newFolder -Password $pw
         Converts myCert.pfx to myCert.pem exposing all certificate details in plain text
     .NOTES
-        General notes
+        Status: Stable
     #>
     [CmdletBinding()]
     Param(

--- a/Public/ConvertTo-PEM.ps1
+++ b/Public/ConvertTo-PEM.ps1
@@ -36,6 +36,8 @@ function ConvertTo-PEM {
         [System.Security.SecureString] $Password
     )
     Begin {
+        Write-Verbose -Message "Starting $($MyInvocation.Mycommand)"
+
         # VALIDATE PASSWORD
         Get-PfxCertificate -FilePath $Path -Password $Password -ErrorAction Stop | Out-Null
 

--- a/Public/ConvertTo-PEM.ps1
+++ b/Public/ConvertTo-PEM.ps1
@@ -28,17 +28,7 @@ function ConvertTo-PEM {
         [System.String] $Path,
 
         [Parameter(HelpMessage = 'Output directory for generated files')]
-        [ValidateScript({
-                if (Test-Path -Path $_ -PathType Leaf) {
-                    Write-Error -Message "OutputDirectory '$_' exists but is a file, not a directory." -ErrorAction Stop
-                }
-                $parent = Split-Path -Path $_ -Parent
-                if ([string]::IsNullOrEmpty($parent)) { $parent = '.' }
-                if (-not (Test-Path -Path $parent -PathType Container)) {
-                    Write-Error -Message "Parent of OutputDirectory does not exist: $parent" -ErrorAction Stop
-                }
-                $true
-            })]
+        [ValidateScript({ Test-OutputDirectoryPath -Path $_ })]
         [System.String] $OutputDirectory = "$HOME\Desktop",
 
         [Parameter(Mandatory, HelpMessage = 'Password to PFX file')]

--- a/Public/ConvertTo-PEM.ps1
+++ b/Public/ConvertTo-PEM.ps1
@@ -56,8 +56,10 @@ function ConvertTo-PEM {
         # is invisible to peer-process listings, ETW process-start events,
         # and EDR command-line telemetry.
         $outFile = Join-Path -Path $OutputDirectory -ChildPath $name
-        [System.Void] (Invoke-OpenSsl `
-            -ArgumentList @('pkcs12', '-in', $PFX, '-out', $outFile, '-nodes', '-passin', 'env:PSSL_PASSIN') `
-            -EnvironmentVariable @{ PSSL_PASSIN = $Password })
+        $sslParams = @{
+            ArgumentList        = @('pkcs12', '-in', $PFX, '-out', $outFile, '-nodes', '-passin', 'env:PSSL_PASSIN')
+            EnvironmentVariable = @{ PSSL_PASSIN = $Password }
+        }
+        [System.Void] (Invoke-OpenSsl @sslParams)
     }
 }

--- a/Public/ConvertTo-PEM.ps1
+++ b/Public/ConvertTo-PEM.ps1
@@ -54,21 +54,10 @@ function ConvertTo-PEM {
     End {
         # VERIFY SIGNED CERTIFICATE
         # openssl pkcs12 -in <PFX_PATH> -out <FILE.TXT> -nodes
-        $sslParams = @{
-            FilePath     = 'openssl' # .exe
-            ArgumentList = @(
-                'pkcs12'
-                '-in {0}' -f $PFX
-                '-out {0}' -f (Join-Path -Path $OutputDirectory -ChildPath $name)
-                '-nodes'
-                '-passin pass:{0}' -f $creds.GetNetworkCredential().Password
-            )
-            Wait         = $true
-            NoNewWindow  = $true
-            PassThru     = $true
-        }
-        $proc = Start-Process @sslParams
-
-        if ($proc.ExitCode -NE 0) { Write-Error -Message ('openssl exited with code: {0}' -f $proc.ExitCode) }
+        # NOTE: -passin pass:... still exposes the password to process listings.
+        #       Item 2a will migrate this to -passin env:VAR using the helper.
+        $outFile = Join-Path -Path $OutputDirectory -ChildPath $name
+        $passInArg = 'pass:{0}' -f $creds.GetNetworkCredential().Password
+        [System.Void] (Invoke-OpenSsl -ArgumentList @('pkcs12', '-in', $PFX, '-out', $outFile, '-nodes', '-passin', $passInArg))
     }
 }

--- a/Public/Export-Base64Certificate.ps1
+++ b/Public/Export-Base64Certificate.ps1
@@ -40,20 +40,15 @@ function Export-Base64Certificate {
         Write-Verbose -Message "Starting $($MyInvocation.Mycommand)"
     }
     Process {
-        # CONVERT BYTE ARRAY TO BASE64 ENCODED STRING
-        $b64s = [System.Convert]::ToBase64String($ByteArray)
-
-        # SET LENGTH OF BASE64 ENCODED STRING
-        $b64sLength = $b64s.Length
-
-        # CREATE ARRAY OF CERTIFICATE DATA
-        $pubCert = @('-----BEGIN CERTIFICATE-----')
-        $pubCert += for ($i = 0; $i -LT $b64s.Length; $i += 64) {
-            if ($b64sLength -ge 64) { $b64s.Substring($i, 64) }
-            else { $b64s.Substring($i, $b64sLength) }
-            $b64sLength -= 64
+        # Base64-encode and wrap at 64 chars per RFC 7468 (PEM) line width.
+        # .NET's Base64FormattingOptions.InsertLineBreaks wraps at 76 (RFC 2045
+        # / MIME), so we slice manually to stay PEM-compliant.
+        $b64 = [System.Convert]::ToBase64String($ByteArray)
+        $lines = for ($i = 0; $i -lt $b64.Length; $i += 64) {
+            $take = [System.Math]::Min(64, $b64.Length - $i)
+            $b64.Substring($i, $take)
         }
-        $pubCert += '-----END CERTIFICATE-----'
+        $pubCert = @('-----BEGIN CERTIFICATE-----') + $lines + '-----END CERTIFICATE-----'
 
         # OUTPUT BASE64 ENCODED CERTIFICATE
         Set-Content -Path $Path -Value $pubCert

--- a/Public/Export-Base64Certificate.ps1
+++ b/Public/Export-Base64Certificate.ps1
@@ -17,11 +17,7 @@ function Export-Base64Certificate {
         PS C:\> Export-Base64Certificate -ByteArray $cert.RawData -Path "$HOME\Desktop\example.com.crt"
         Convert the remote SSL certificate byte array to a base64 encoded certificate file and save to the desktop
     .NOTES
-        Name:     Export-Base64Certificate
-        Author:   Justin Johns
-        Version:  0.1.2 | Last Edit: 2026-05-22
-        - Version history is captured in repository commit history
-        Comments: <Comment(s)>
+        Status: Stable
     #>
     [CmdletBinding()]
     [OutputType([System.String])]

--- a/Public/Export-Base64Certificate.ps1
+++ b/Public/Export-Base64Certificate.ps1
@@ -19,7 +19,7 @@ function Export-Base64Certificate {
     .NOTES
         Name:     Export-Base64Certificate
         Author:   Justin Johns
-        Version:  0.1.1 | Last Edit: 2024-06-27
+        Version:  0.1.2 | Last Edit: 2026-05-22
         - Version history is captured in repository commit history
         Comments: <Comment(s)>
     #>

--- a/Public/Export-CertificateData.ps1
+++ b/Public/Export-CertificateData.ps1
@@ -1,29 +1,66 @@
 function Export-CertificateData {
     <#
     .SYNOPSIS
-        Short description
+        Split a combined PEM bundle into separate certificate, chain, and
+        private key files.
     .DESCRIPTION
-        Long description
+        Reads a PEM file that contains a private key followed by one or more
+        concatenated certificates (typical of a fullchain export) and writes
+        the requested portion to a new PEM file in -OutputDirectory.
+
+        The function does not invoke openssl; it scans the input line-by-line
+        for the standard PEM begin/end markers and copies the matching block
+        verbatim, preserving the original encoding.
+
+        Expected layout of the input PEM:
+          -----BEGIN PRIVATE KEY-----   (optional, required for -Data PrivateKey)
+          ...
+          -----END PRIVATE KEY-----
+          -----BEGIN CERTIFICATE-----   (leaf certificate; required for -Data Certificate)
+          ...
+          -----END CERTIFICATE-----
+          -----BEGIN CERTIFICATE-----   (chain certs; required for -Data Chain)
+          ...
+          -----END CERTIFICATE-----
+          ...
+
+        The output filename is fixed per -Data value and is written under
+        -OutputDirectory:
+          Certificate -> certificate.pem  (first CERTIFICATE block)
+          Chain       -> chain.pem        (2nd through 4th CERTIFICATE blocks, concatenated)
+          PrivateKey  -> PRIVATE.key      (PRIVATE KEY block)
     .PARAMETER Path
-        Path to PEM file
+        Path to a PEM file. Must exist and have a .pem extension.
     .PARAMETER OutputDirectory
-        Output directory for Certificate Data
+        Directory the split file will be written into. Created if missing.
+        Defaults to the current user's Desktop.
     .PARAMETER Data
-        Data to export
+        Which portion of the bundle to extract. One of:
+          Certificate -- the leaf certificate (first CERTIFICATE block)
+          Chain       -- the chain certificates (2nd through 4th CERTIFICATE blocks)
+          PrivateKey  -- the unencrypted private key (PRIVATE KEY block)
     .INPUTS
-        None.
+        None. This function does not accept pipeline input.
     .OUTPUTS
-        None.
+        None. The function writes a file to -OutputDirectory as a side effect.
     .EXAMPLE
-        PS C:\> Export-CertificateData -Path C:\cert.pem -Data Chain
-        Export the certificate chain for SSL certificate
+        PS C:\> Export-CertificateData -Path .\fullchain.pem -Data Certificate -OutputDirectory .\out
+        Writes .\out\certificate.pem containing only the leaf certificate from fullchain.pem.
+    .EXAMPLE
+        PS C:\> Export-CertificateData -Path .\fullchain.pem -Data Chain -OutputDirectory .\out
+        Writes .\out\chain.pem containing the intermediate and root certificates
+        (up to three) concatenated in the original order.
+    .EXAMPLE
+        PS C:\> Export-CertificateData -Path .\fullchain.pem -Data PrivateKey -OutputDirectory .\out
+        Writes .\out\PRIVATE.key containing only the private key block.
     .NOTES
-        Name:     Export-CertificateData
-        Author:   Justin Johns
-        Version:  0.1.0 | Last Edit: 2022-09-30
-        - Version history is captured in repository commit history
-        Comments: <Comment(s)>
-        General notes:
+        Name:    Export-CertificateData
+        Author:  Justin Johns
+        - Chain extraction is currently capped at the 2nd through 4th
+          CERTIFICATE blocks (intermediates plus an optional root). Bundles
+          with more than four CERTIFICATE blocks will silently drop the rest.
+        - Output filenames are fixed and will overwrite any existing file of
+          the same name in -OutputDirectory.
     #>
     [CmdletBinding()]
     Param(

--- a/Public/Export-CertificateData.ps1
+++ b/Public/Export-CertificateData.ps1
@@ -54,8 +54,7 @@ function Export-CertificateData {
         PS C:\> Export-CertificateData -Path .\fullchain.pem -Data PrivateKey -OutputDirectory .\out
         Writes .\out\PRIVATE.key containing only the private key block.
     .NOTES
-        Name:    Export-CertificateData
-        Author:  Justin Johns
+        Status: Beta
         - Chain extraction is currently capped at the 2nd through 4th
           CERTIFICATE blocks (intermediates plus an optional root). Bundles
           with more than four CERTIFICATE blocks will silently drop the rest.

--- a/Public/Export-CertificateData.ps1
+++ b/Public/Export-CertificateData.ps1
@@ -31,8 +31,18 @@ function Export-CertificateData {
         [ValidateScript({ Test-Path -Path $_ -PathType Leaf -Filter '*.pem' })]
         [System.String] $Path,
 
-        [Parameter(Position = 1, HelpMessage = 'Output report directory')]
-        [ValidateScript({ Test-Path -Path (Split-Path -Path $_) -PathType Container })]
+        [Parameter(Position = 1, HelpMessage = 'Output directory for generated files')]
+        [ValidateScript({
+                if (Test-Path -Path $_ -PathType Leaf) {
+                    Write-Error -Message "OutputDirectory '$_' exists but is a file, not a directory." -ErrorAction Stop
+                }
+                $parent = Split-Path -Path $_ -Parent
+                if ([string]::IsNullOrEmpty($parent)) { $parent = '.' }
+                if (-not (Test-Path -Path $parent -PathType Container)) {
+                    Write-Error -Message "Parent of OutputDirectory does not exist: $parent" -ErrorAction Stop
+                }
+                $true
+            })]
         [System.String] $OutputDirectory = "$HOME\Desktop",
 
         [Parameter(Mandatory, Position = 2, HelpMessage = 'Data to export')]
@@ -42,9 +52,8 @@ function Export-CertificateData {
     Begin {
         Write-Verbose -Message "Starting $($MyInvocation.Mycommand)"
 
-        # UPDATE OUTPUT DIRECTORY AND CREATE FOLDER
-        #$OutputDirectory = Join-Path -Path $OutputDirectory -ChildPath ([System.IO.Path]::GetRandomFileName().Remove(8, 4))
-        #New-Item -Path $OutputDirectory -ItemType Directory | Write-Verbose
+        # GET OUTPUT DIRECTORY
+        Initialize-OutputDirectory -Path $OutputDirectory
 
         # GET PEM CONTENT
         $pemContent = Get-Content -Path $Path

--- a/Public/Export-CertificateData.ps1
+++ b/Public/Export-CertificateData.ps1
@@ -32,17 +32,7 @@ function Export-CertificateData {
         [System.String] $Path,
 
         [Parameter(Position = 1, HelpMessage = 'Output directory for generated files')]
-        [ValidateScript({
-                if (Test-Path -Path $_ -PathType Leaf) {
-                    Write-Error -Message "OutputDirectory '$_' exists but is a file, not a directory." -ErrorAction Stop
-                }
-                $parent = Split-Path -Path $_ -Parent
-                if ([string]::IsNullOrEmpty($parent)) { $parent = '.' }
-                if (-not (Test-Path -Path $parent -PathType Container)) {
-                    Write-Error -Message "Parent of OutputDirectory does not exist: $parent" -ErrorAction Stop
-                }
-                $true
-            })]
+        [ValidateScript({ Test-OutputDirectoryPath -Path $_ })]
         [System.String] $OutputDirectory = "$HOME\Desktop",
 
         [Parameter(Mandatory, Position = 2, HelpMessage = 'Data to export')]

--- a/Public/Export-CertificateData.ps1
+++ b/Public/Export-CertificateData.ps1
@@ -64,11 +64,7 @@ function Export-CertificateData {
     [CmdletBinding()]
     Param(
         [Parameter(Mandatory, Position = 0, HelpMessage = 'Path to PEM file')]
-        # Test-Path -Filter / -Include are silently ignored when -Path is a
-        # literal value (they only filter when -Path contains a wildcard), so
-        # the extension check has to be explicit. -like '*.pem' is the
-        # smallest correct form; the surrounding Test-Path enforces existence.
-        [ValidateScript({ (Test-Path -Path $_ -PathType Leaf) -and ($_ -like '*.pem') })]
+        [ValidateScript({ Test-Path -Path $_ -PathType Leaf -Include '*.pem' })]
         [System.String] $Path,
 
         [Parameter(Position = 1, HelpMessage = 'Output directory for generated files')]

--- a/Public/Export-CertificateData.ps1
+++ b/Public/Export-CertificateData.ps1
@@ -64,7 +64,11 @@ function Export-CertificateData {
     [CmdletBinding()]
     Param(
         [Parameter(Mandatory, Position = 0, HelpMessage = 'Path to PEM file')]
-        [ValidateScript({ Test-Path -Path $_ -PathType Leaf -Filter '*.pem' })]
+        # Test-Path -Filter / -Include are silently ignored when -Path is a
+        # literal value (they only filter when -Path contains a wildcard), so
+        # the extension check has to be explicit. -like '*.pem' is the
+        # smallest correct form; the surrounding Test-Path enforces existence.
+        [ValidateScript({ (Test-Path -Path $_ -PathType Leaf) -and ($_ -like '*.pem') })]
         [System.String] $Path,
 
         [Parameter(Position = 1, HelpMessage = 'Output directory for generated files')]

--- a/Public/Export-CertificateData.ps1
+++ b/Public/Export-CertificateData.ps1
@@ -21,7 +21,7 @@ function Export-CertificateData {
         Name:     Export-CertificateData
         Author:   Justin Johns
         Version:  0.1.0 | Last Edit: 2022-09-30
-        - 0.1.0 - Initial version
+        - Version history is captured in repository commit history
         Comments: <Comment(s)>
         General notes:
     #>

--- a/Public/Export-PFX.ps1
+++ b/Public/Export-PFX.ps1
@@ -29,7 +29,7 @@ function Export-PFX {
         General notes
         https://man.openbsd.org/openssl.1
     #>
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = '__nochain')]
     Param(
         [Parameter(HelpMessage = 'Output directory for CSR and key file')]
         [ValidateScript({ Test-Path -Path (Split-Path -Path $_) -PathType Container })]
@@ -47,11 +47,12 @@ function Export-PFX {
         [ValidateScript({ Test-Path -Path $_ -PathType Leaf -Include '*.crt', '*.cer', '*.pem' })]
         [System.String] $SignedCSR,
 
-        [Parameter(HelpMessage = 'Path to root CA public certificate')]
+        [Parameter(Mandatory, ParameterSetName = '__rootonly', HelpMessage = 'Path to root CA public certificate')]
+        [Parameter(Mandatory, ParameterSetName = '__fullchain', HelpMessage = 'Path to root CA public certificate')]
         [ValidateScript({ Test-Path -Path $_ -PathType Leaf -Include '*.crt', '*.cer', '*.pem' })]
         [System.String] $RootCA,
 
-        [Parameter(HelpMessage = 'Path to intermediate CA public certificate')]
+        [Parameter(Mandatory, ParameterSetName = '__fullchain', HelpMessage = 'Path to intermediate CA public certificate')]
         [ValidateScript({ Test-Path -Path $_ -PathType Leaf -Include '*.crt', '*.cer', '*.pem' })]
         [System.String] $IntermediateCA,
 
@@ -65,14 +66,16 @@ function Export-PFX {
         # SET PFX PATH - THIS CAN ALSO BE A ".P12" IF DESIRED
         $pfxPath = Join-Path -Path $OutputDirectory -ChildPath ('{0}.pfx' -f (Split-Path -Path $SignedCSR -LeafBase))
 
-        # COMBINE CERTIFICATES IN CHAIN
-        if ($PSBoundParameters.ContainsKey('IntermediateCA')) {
-            $chain = Join-Path -Path $OutputDirectory -ChildPath 'CAChain.crt'
-            Get-Content -Path $IntermediateCA | Set-Content -Path $chain
-            Get-Content -Path $RootCA | Add-Content -Path $chain
-        }
-        elseif ($PSBoundParameters.ContainsKey('RootCA')) {
-            $chain = $RootCA
+        # COMBINE CERTIFICATES IN CHAIN (parameter set guarantees RootCA is present when IntermediateCA is)
+        switch ($PSCmdlet.ParameterSetName) {
+            '__fullchain' {
+                $chain = Join-Path -Path $OutputDirectory -ChildPath 'CAChain.crt'
+                Get-Content -Path $IntermediateCA | Set-Content -Path $chain
+                Get-Content -Path $RootCA | Add-Content -Path $chain
+            }
+            '__rootonly' {
+                $chain = $RootCA
+            }
         }
 
         # CREATE CREDENTIAL OBJECT WITH PASSWORD

--- a/Public/Export-PFX.ps1
+++ b/Public/Export-PFX.ps1
@@ -8,14 +8,14 @@ function Export-PFX {
         Output directory for new PFX file
     .PARAMETER Password
         Password used to protect exported PFX file
-    .PARAMETER Key
-        Path to private key file
-    .PARAMETER SignedCSR
-        Path to CA-signed certificate request
-    .PARAMETER RootCA
-        Path to root CA public certificate
-    .PARAMETER IntermediateCA
-        Path to intermediate CA public certificate
+    .PARAMETER KeyPath
+        Path to private key file. Accepts the legacy alias -Key.
+    .PARAMETER SignedCSRPath
+        Path to CA-signed certificate request. Accepts the legacy alias -SignedCSR.
+    .PARAMETER RootCAPath
+        Path to root CA public certificate. Accepts the legacy alias -RootCA.
+    .PARAMETER IntermediateCAPath
+        Path to intermediate CA public certificate. Accepts the legacy alias -IntermediateCA.
     .PARAMETER WindowsCompatible
         Export using PBE-SHA1-3DES algorithm
     .INPUTS
@@ -23,7 +23,7 @@ function Export-PFX {
     .OUTPUTS
         System.Object.
     .EXAMPLE
-        PS C:\> Export-PFX -Password $secStr -Key .\key.key - SignedCSR .\cert.crt -RootCA .\root.crt
+        PS C:\> Export-PFX -Password $secStr -KeyPath .\key.key -SignedCSRPath .\cert.crt -RootCAPath .\root.crt
         Creates and exports PFX file from private key, signed certificate, and root CA
     .NOTES
         General notes
@@ -41,20 +41,24 @@ function Export-PFX {
 
         [Parameter(Mandatory, HelpMessage = 'Path to private key file')]
         [ValidateScript({ Test-Path -Path $_ -PathType Leaf -Include '*.key', '*.pem' })]
-        [System.String] $Key,
+        [Alias('Key')]
+        [System.String] $KeyPath,
 
         [Parameter(Mandatory, HelpMessage = 'Path to CA-signed certificate request')]
         [ValidateScript({ Test-Path -Path $_ -PathType Leaf -Include '*.crt', '*.cer', '*.pem' })]
-        [System.String] $SignedCSR,
+        [Alias('SignedCSR')]
+        [System.String] $SignedCSRPath,
 
         [Parameter(Mandatory, ParameterSetName = '__rootonly', HelpMessage = 'Path to root CA public certificate')]
         [Parameter(Mandatory, ParameterSetName = '__fullchain', HelpMessage = 'Path to root CA public certificate')]
         [ValidateScript({ Test-Path -Path $_ -PathType Leaf -Include '*.crt', '*.cer', '*.pem' })]
-        [System.String] $RootCA,
+        [Alias('RootCA')]
+        [System.String] $RootCAPath,
 
         [Parameter(Mandatory, ParameterSetName = '__fullchain', HelpMessage = 'Path to intermediate CA public certificate')]
         [ValidateScript({ Test-Path -Path $_ -PathType Leaf -Include '*.crt', '*.cer', '*.pem' })]
-        [System.String] $IntermediateCA,
+        [Alias('IntermediateCA')]
+        [System.String] $IntermediateCAPath,
 
         [Parameter(HelpMessage = 'Export using PBE-SHA1-3DES algorithm')]
         [System.Management.Automation.SwitchParameter] $WindowsCompatible
@@ -64,17 +68,17 @@ function Export-PFX {
         if (-not (Test-Path -Path $OutputDirectory)) { New-Item -Path $OutputDirectory -ItemType Directory | Out-Null }
 
         # SET PFX PATH - THIS CAN ALSO BE A ".P12" IF DESIRED
-        $pfxPath = Join-Path -Path $OutputDirectory -ChildPath ('{0}.pfx' -f (Split-Path -Path $SignedCSR -LeafBase))
+        $pfxPath = Join-Path -Path $OutputDirectory -ChildPath ('{0}.pfx' -f (Split-Path -Path $SignedCSRPath -LeafBase))
 
         # COMBINE CERTIFICATES IN CHAIN (parameter set guarantees RootCA is present when IntermediateCA is)
         switch ($PSCmdlet.ParameterSetName) {
             '__fullchain' {
                 $chain = Join-Path -Path $OutputDirectory -ChildPath 'CAChain.crt'
-                Get-Content -Path $IntermediateCA | Set-Content -Path $chain
-                Get-Content -Path $RootCA | Add-Content -Path $chain
+                Get-Content -Path $IntermediateCAPath | Set-Content -Path $chain
+                Get-Content -Path $RootCAPath | Add-Content -Path $chain
             }
             '__rootonly' {
-                $chain = $RootCA
+                $chain = $RootCAPath
             }
         }
     }
@@ -89,8 +93,8 @@ function Export-PFX {
         $opensslArgs.AddRange([System.String[]] @(
             'pkcs12', '-export',
             '-out', $pfxPath,
-            '-inkey', $Key,
-            '-in', $SignedCSR,
+            '-inkey', $KeyPath,
+            '-in', $SignedCSRPath,
             '-passout', 'env:PSSL_PASSOUT'
         ))
 

--- a/Public/Export-PFX.ps1
+++ b/Public/Export-PFX.ps1
@@ -31,8 +31,18 @@ function Export-PFX {
     #>
     [CmdletBinding(DefaultParameterSetName = '__nochain')]
     Param(
-        [Parameter(HelpMessage = 'Output directory for CSR and key file')]
-        [ValidateScript({ Test-Path -Path (Split-Path -Path $_) -PathType Container })]
+        [Parameter(HelpMessage = 'Output directory for generated files')]
+        [ValidateScript({
+                if (Test-Path -Path $_ -PathType Leaf) {
+                    Write-Error -Message "OutputDirectory '$_' exists but is a file, not a directory." -ErrorAction Stop
+                }
+                $parent = Split-Path -Path $_ -Parent
+                if ([string]::IsNullOrEmpty($parent)) { $parent = '.' }
+                if (-not (Test-Path -Path $parent -PathType Container)) {
+                    Write-Error -Message "Parent of OutputDirectory does not exist: $parent" -ErrorAction Stop
+                }
+                $true
+            })]
         [System.String] $OutputDirectory = "$HOME\Desktop",
 
         [Parameter(Mandatory, HelpMessage = 'Password used to protect exported PFX file')]
@@ -65,7 +75,7 @@ function Export-PFX {
     )
     Begin {
         # GET OUTPUT DIRECTORY
-        if (-not (Test-Path -Path $OutputDirectory)) { New-Item -Path $OutputDirectory -ItemType Directory | Out-Null }
+        Initialize-OutputDirectory -Path $OutputDirectory
 
         # SET PFX PATH - THIS CAN ALSO BE A ".P12" IF DESIRED
         $pfxPath = Join-Path -Path $OutputDirectory -ChildPath ('{0}.pfx' -f (Split-Path -Path $SignedCSRPath -LeafBase))

--- a/Public/Export-PFX.ps1
+++ b/Public/Export-PFX.ps1
@@ -32,17 +32,7 @@ function Export-PFX {
     [CmdletBinding(DefaultParameterSetName = '__nochain')]
     Param(
         [Parameter(HelpMessage = 'Output directory for generated files')]
-        [ValidateScript({
-                if (Test-Path -Path $_ -PathType Leaf) {
-                    Write-Error -Message "OutputDirectory '$_' exists but is a file, not a directory." -ErrorAction Stop
-                }
-                $parent = Split-Path -Path $_ -Parent
-                if ([string]::IsNullOrEmpty($parent)) { $parent = '.' }
-                if (-not (Test-Path -Path $parent -PathType Container)) {
-                    Write-Error -Message "Parent of OutputDirectory does not exist: $parent" -ErrorAction Stop
-                }
-                $true
-            })]
+        [ValidateScript({ Test-OutputDirectoryPath -Path $_ })]
         [System.String] $OutputDirectory = "$HOME\Desktop",
 
         [Parameter(Mandatory, HelpMessage = 'Password used to protect exported PFX file')]

--- a/Public/Export-PFX.ps1
+++ b/Public/Export-PFX.ps1
@@ -82,37 +82,37 @@ function Export-PFX {
         $creds = [System.Management.Automation.PSCredential]::new('UserName', $Password)
     }
     End {
-        # SET OPENSSL PARAMETERS
+        # SET OPENSSL ARGUMENTS
         # openssl pkcs12 -export -out myDomain.com.pfx -inkey myDomain.com.key -in myDomain.com.crt -certfile CertChain.crt
-        $sslParams = @{
-            FilePath     = 'openssl' # .exe
-            ArgumentList = @(
-                'pkcs12 -export'
-                '-out {0}' -f $pfxPath
-                '-inkey {0}' -f $Key
-                '-in {0}' -f $SignedCSR
-                #'-certfile {0}' -f $chain
-                '-passout pass:{0}' -f $creds.GetNetworkCredential().Password
-            )
-            Wait         = $true
-            NoNewWindow  = $true
-            PassThru     = $true
-        }
+        # NOTE: -passout pass:... still exposes the password to process listings.
+        #       Item 2a will migrate this to -passout env:VAR using the helper.
+        $passOutArg = 'pass:{0}' -f $creds.GetNetworkCredential().Password
+        $opensslArgs = [System.Collections.Generic.List[System.String]]::new()
+        $opensslArgs.AddRange([System.String[]] @(
+            'pkcs12', '-export',
+            '-out', $pfxPath,
+            '-inkey', $Key,
+            '-in', $SignedCSR,
+            '-passout', $passOutArg
+        ))
 
         # ADD CERTIFICATE CHAIN
-        if ($chain) { $sslParams.ArgumentList += '-certfile {0}' -f $chain }
+        if ($chain) { $opensslArgs.AddRange([System.String[]] @('-certfile', $chain)) }
 
         # OUTPUT CERTIFICATE AND KEY USING PBE-SHA1-3DES ALGORITHM
         # THIS IS NEEDED FOR WINDOWS SERVER COMPATIBILITY
         if ($WindowsCompatible) {
-            $sslParams['ArgumentList'] += '-certpbe PBE-SHA1-3DES -keypbe PBE-SHA1-3DES -nomac'
+            $opensslArgs.AddRange([System.String[]] @(
+                '-certpbe', 'PBE-SHA1-3DES',
+                '-keypbe', 'PBE-SHA1-3DES',
+                '-nomac'
+            ))
         }
 
-        # START OPENSSL
-        $proc = Start-Process @sslParams
+        # INVOKE OPENSSL
+        [System.Void] (Invoke-OpenSsl -ArgumentList $opensslArgs.ToArray())
 
-        # RETURN RESULT
-        if ($proc.ExitCode -NE 0) { Write-Error -Message ('openssl exited with code: {0}' -f $proc.ExitCode) }
-        else { Write-Output -InputObject $pfxPath }
+        # RETURN PFX PATH
+        Write-Output -InputObject $pfxPath
     }
 }

--- a/Public/Export-PFX.ps1
+++ b/Public/Export-PFX.ps1
@@ -26,7 +26,8 @@ function Export-PFX {
         PS C:\> Export-PFX -Password $secStr -KeyPath .\key.key -SignedCSRPath .\cert.crt -RootCAPath .\root.crt
         Creates and exports PFX file from private key, signed certificate, and root CA
     .NOTES
-        General notes
+        Status: Stable
+        References:
         https://man.openbsd.org/openssl.1
     #>
     [CmdletBinding(DefaultParameterSetName = '__nochain')]

--- a/Public/Export-PFX.ps1
+++ b/Public/Export-PFX.ps1
@@ -65,6 +65,8 @@ function Export-PFX {
         [System.Management.Automation.SwitchParameter] $WindowsCompatible
     )
     Begin {
+        Write-Verbose -Message "Starting $($MyInvocation.Mycommand)"
+
         # GET OUTPUT DIRECTORY
         Initialize-OutputDirectory -Path $OutputDirectory
 

--- a/Public/Export-PFX.ps1
+++ b/Public/Export-PFX.ps1
@@ -77,23 +77,21 @@ function Export-PFX {
                 $chain = $RootCA
             }
         }
-
-        # CREATE CREDENTIAL OBJECT WITH PASSWORD
-        $creds = [System.Management.Automation.PSCredential]::new('UserName', $Password)
     }
     End {
         # SET OPENSSL ARGUMENTS
         # openssl pkcs12 -export -out myDomain.com.pfx -inkey myDomain.com.key -in myDomain.com.crt -certfile CertChain.crt
-        # NOTE: -passout pass:... still exposes the password to process listings.
-        #       Item 2a will migrate this to -passout env:VAR using the helper.
-        $passOutArg = 'pass:{0}' -f $creds.GetNetworkCredential().Password
+        # PASS THE PFX PASSWORD VIA AN ENVIRONMENT VARIABLE SCOPED TO THE
+        # OPENSSL CHILD PROCESS - never on argv, never in the parent session
+        # - so it is invisible to peer-process listings, ETW process-start
+        # events, and EDR command-line telemetry.
         $opensslArgs = [System.Collections.Generic.List[System.String]]::new()
         $opensslArgs.AddRange([System.String[]] @(
             'pkcs12', '-export',
             '-out', $pfxPath,
             '-inkey', $Key,
             '-in', $SignedCSR,
-            '-passout', $passOutArg
+            '-passout', 'env:PSSL_PASSOUT'
         ))
 
         # ADD CERTIFICATE CHAIN
@@ -110,7 +108,11 @@ function Export-PFX {
         }
 
         # INVOKE OPENSSL
-        [System.Void] (Invoke-OpenSsl -ArgumentList $opensslArgs.ToArray())
+        $sslParams = @{
+            ArgumentList        = $opensslArgs.ToArray()
+            EnvironmentVariable = @{ PSSL_PASSOUT = $Password }
+        }
+        [System.Void] (Invoke-OpenSsl @sslParams)
 
         # RETURN PFX PATH
         Write-Output -InputObject $pfxPath

--- a/Public/Get-CSRData.ps1
+++ b/Public/Get-CSRData.ps1
@@ -1,31 +1,115 @@
 function Get-CSRData {
     <#
     .SYNOPSIS
-        Confirm CSR
+        Parse and verify a certificate signing request (CSR).
     .DESCRIPTION
-        Confirm/validate details of certificate signing request (CSR)
+        Calls `openssl req -text -noout -verify` on the given CSR file, parses
+        the human-readable output, and returns a structured PSCustomObject
+        with the most commonly-inspected fields plus the full raw text.
+
+        The verification result (openssl's "Certificate request self-signature
+        verify OK" / "Signature did not match" message, written to stderr) is
+        surfaced as a boolean property. Verification failure does NOT
+        terminate the function so callers can report on invalid CSRs too.
     .PARAMETER CSR
-        Path to certificate signing request (CSR)
+        Path to a certificate signing request (.csr) file.
     .INPUTS
-        System.String.
+        System.String. Pipe a file path.
     .OUTPUTS
-        System.Object.
+        System.Management.Automation.PSCustomObject with properties:
+          Path, Subject, PublicKeyAlgorithm, PublicKeyBits,
+          SignatureAlgorithm, SubjectAlternativeName, Verified, Raw.
     .EXAMPLE
-        PS C:\> <example usage>
-        Explanation of what the example does
+        PS C:\> Get-CSRData -CSR .\example.csr | Select-Object Subject, Verified
+        Inspect summary fields.
+    .EXAMPLE
+        PS C:\> (Get-CSRData -CSR .\example.csr).Raw
+        Print the full openssl -text dump (preserves the pre-3a output format
+        for callers that want the original visual review experience).
     .NOTES
-        General notes
+        Name:      Get-CSRData
+        Author:    Justin Johns
+        - Field extraction is regex-based against openssl's human output
+          because no public .NET CSR-loader exists at PS 7.0 / .NET Core 3.1
+          (CertificateRequest.LoadSigningRequest is .NET 7+). Unmatched
+          fields become $null rather than throwing.
+        - BREAKING CHANGE from prior versions: this function returned the
+          raw multi-line openssl text dump. It now returns a structured
+          object; the original text is preserved on the .Raw property.
     #>
+    [OutputType([System.Management.Automation.PSCustomObject])]
     [CmdletBinding()]
     Param(
         [Parameter(Mandatory, ValueFromPipeline, HelpMessage = 'Path to CA-signed certificate request')]
-        [ValidateScript({ Test-Path -Path $_ -PathType Leaf -Include "*.csr" })]
+        [ValidateScript({
+                if (-not (Test-Path -Path $_ -PathType Leaf)) { Write-Error -Message "File not found: $_" -ErrorAction Stop }
+                $ext = [System.IO.Path]::GetExtension($_).ToLowerInvariant()
+                if ($ext -ne '.csr') { Write-Error -Message "Unsupported extension '$ext'. Expected .csr." -ErrorAction Stop }
+                $true
+            })]
         [System.String] $CSR
     )
     Process {
-        # VERIFY UNSIGNED CSR
-        # openssl req -text -noout -verify -in company_san.csr
-        $result = Invoke-OpenSsl -ArgumentList @('req', '-text', '-noout', '-verify', '-in', $CSR)
-        $result.StdOut
+        # openssl req -text -noout -verify -in <csr>
+        # -IgnoreExitCode: a verification failure should produce a structured
+        # object with Verified=$false, not terminate.
+        $sslParams = @{
+            ArgumentList    = @('req', '-text', '-noout', '-verify', '-in', $CSR)
+            IgnoreExitCode  = $true
+        }
+        $result = Invoke-OpenSsl @sslParams
+
+        $text = if ($result.StdOut) { $result.StdOut } else { '' }
+
+        # Subject: e.g. "        Subject: C = US, ST = California, ..., CN = example.com"
+        $subject = $null
+        if ($text -match '(?m)^\s*Subject:\s*(.+?)\s*$') { $subject = $Matches[1] }
+
+        # Public-Key: e.g. "                Public-Key: (4096 bit)"
+        $publicKeyBits = $null
+        if ($text -match '(?m)^\s*Public-Key:\s*\((\d+)\s*bit\)') { $publicKeyBits = [int] $Matches[1] }
+
+        # Public Key Algorithm: e.g. "            Public Key Algorithm: rsaEncryption"
+        $publicKeyAlgorithm = $null
+        if ($text -match '(?m)^\s*Public Key Algorithm:\s*(.+?)\s*$') { $publicKeyAlgorithm = $Matches[1] }
+
+        # Signature Algorithm appears twice in CSR -text output (once inside
+        # the SubjectPublicKeyInfo block, once at the request-signature
+        # block). The LAST occurrence is the algorithm used to sign the
+        # request, which is what callers actually care about.
+        $signatureAlgorithm = $null
+        $sigMatches = [regex]::Matches($text, '(?m)^\s*Signature Algorithm:\s*(.+?)\s*$')
+        if ($sigMatches.Count -gt 0) {
+            $signatureAlgorithm = $sigMatches[$sigMatches.Count - 1].Groups[1].Value
+        }
+
+        # SANs appear on the line immediately following the header:
+        #     X509v3 Subject Alternative Name:
+        #         DNS:a.example.com, DNS:b.example.com
+        $sans = @()
+        if ($text -match 'X509v3 Subject Alternative Name:\s*[\r\n]+\s*([^\r\n]+)') {
+            $sans = @(
+                $Matches[1] -split ',\s*' | ForEach-Object {
+                    if ($_ -match '^\s*DNS:(.+)$') { $Matches[1].Trim() } else { $_.Trim() }
+                } | Where-Object { $_ }
+            )
+        }
+
+        # openssl's verify message is written to STDOUT (not stderr) in
+        # 1.1.x, 3.x, and 4.x. Tolerate both the verbose 3.x/4.x wording
+        # ("Certificate request self-signature verify OK") and the older
+        # 1.1.x phrasing ("verify OK").
+        $verified = ($text -match 'self-signature verify OK' -or $text -match '(?m)^\s*verify OK\s*$')
+
+        [PSCustomObject] @{
+            Path                   = $CSR
+            Subject                = $subject
+            PublicKeyAlgorithm     = $publicKeyAlgorithm
+            PublicKeyBits          = $publicKeyBits
+            SignatureAlgorithm     = $signatureAlgorithm
+            SubjectAlternativeName = $sans
+            Verified               = $verified
+            Raw                    = $text
+        }
     }
 }

--- a/Public/Get-CSRData.ps1
+++ b/Public/Get-CSRData.ps1
@@ -28,8 +28,7 @@ function Get-CSRData {
         Print the full openssl -text dump (preserves the pre-3a output format
         for callers that want the original visual review experience).
     .NOTES
-        Name:      Get-CSRData
-        Author:    Justin Johns
+        Status: Beta
         - Field extraction is regex-based against openssl's human output
           because no public .NET CSR-loader exists at PS 7.0 / .NET Core 3.1
           (CertificateRequest.LoadSigningRequest is .NET 7+). Unmatched

--- a/Public/Get-CSRData.ps1
+++ b/Public/Get-CSRData.ps1
@@ -50,6 +50,9 @@ function Get-CSRData {
         [Alias('CSR')]
         [System.String] $Path
     )
+    Begin {
+        Write-Verbose -Message "Starting $($MyInvocation.Mycommand)"
+    }
     Process {
         # openssl req -text -noout -verify -in <csr>
         # -IgnoreExitCode: a verification failure should produce a structured

--- a/Public/Get-CSRData.ps1
+++ b/Public/Get-CSRData.ps1
@@ -11,8 +11,9 @@ function Get-CSRData {
         verify OK" / "Signature did not match" message, written to stderr) is
         surfaced as a boolean property. Verification failure does NOT
         terminate the function so callers can report on invalid CSRs too.
-    .PARAMETER CSR
-        Path to a certificate signing request (.csr) file.
+    .PARAMETER Path
+        Path to a certificate signing request (.csr) file. Accepts the legacy
+        alias -CSR.
     .INPUTS
         System.String. Pipe a file path.
     .OUTPUTS
@@ -20,10 +21,10 @@ function Get-CSRData {
           Path, Subject, PublicKeyAlgorithm, PublicKeyBits,
           SignatureAlgorithm, SubjectAlternativeName, Verified, Raw.
     .EXAMPLE
-        PS C:\> Get-CSRData -CSR .\example.csr | Select-Object Subject, Verified
+        PS C:\> Get-CSRData -Path .\example.csr | Select-Object Subject, Verified
         Inspect summary fields.
     .EXAMPLE
-        PS C:\> (Get-CSRData -CSR .\example.csr).Raw
+        PS C:\> (Get-CSRData -Path .\example.csr).Raw
         Print the full openssl -text dump (preserves the pre-3a output format
         for callers that want the original visual review experience).
     .NOTES
@@ -47,14 +48,15 @@ function Get-CSRData {
                 if ($ext -ne '.csr') { Write-Error -Message "Unsupported extension '$ext'. Expected .csr." -ErrorAction Stop }
                 $true
             })]
-        [System.String] $CSR
+        [Alias('CSR')]
+        [System.String] $Path
     )
     Process {
         # openssl req -text -noout -verify -in <csr>
         # -IgnoreExitCode: a verification failure should produce a structured
         # object with Verified=$false, not terminate.
         $sslParams = @{
-            ArgumentList    = @('req', '-text', '-noout', '-verify', '-in', $CSR)
+            ArgumentList    = @('req', '-text', '-noout', '-verify', '-in', $Path)
             IgnoreExitCode  = $true
         }
         $result = Invoke-OpenSsl @sslParams
@@ -102,7 +104,7 @@ function Get-CSRData {
         $verified = ($text -match 'self-signature verify OK' -or $text -match '(?m)^\s*verify OK\s*$')
 
         [PSCustomObject] @{
-            Path                   = $CSR
+            Path                   = $Path
             Subject                = $subject
             PublicKeyAlgorithm     = $publicKeyAlgorithm
             PublicKeyBits          = $publicKeyBits

--- a/Public/Get-CSRData.ps1
+++ b/Public/Get-CSRData.ps1
@@ -25,18 +25,7 @@ function Get-CSRData {
     Process {
         # VERIFY UNSIGNED CSR
         # openssl req -text -noout -verify -in company_san.csr
-        $sslParams = @{
-            FilePath     = 'openssl' # .exe
-            ArgumentList = @(
-                'req -text -noout -verify'
-                '-in {0}' -f $CSR
-            )
-            Wait         = $true
-            NoNewWindow  = $true
-            PassThru     = $true
-        }
-        $proc = Start-Process @sslParams
-
-        if ($proc.ExitCode -NE 0) { Write-Error -Message ('openssl exited with code: {0}' -f $proc.ExitCode) }
+        $result = Invoke-OpenSsl -ArgumentList @('req', '-text', '-noout', '-verify', '-in', $CSR)
+        $result.StdOut
     }
 }

--- a/Public/Get-CSRTemplate.ps1
+++ b/Public/Get-CSRTemplate.ps1
@@ -1,0 +1,62 @@
+function Get-CSRTemplate {
+    <#
+    .SYNOPSIS
+        Return the canonical openssl req configuration template used by the module.
+    .DESCRIPTION
+        Emits the openssl `req` config template that the module's New-CertificateSigningRequest
+        and New-SelfSignedCertificate functions render internally when generating a CSR or
+        self-signed certificate from scratch (i.e. when the caller does not supply their own
+        -ConfigFile).
+
+        Use this when you want to seed a custom .conf file - write the template to disk, edit
+        the placeholders by hand, then feed the resulting file back into New-CertificateSigningRequest
+        or New-SelfSignedCertificate via -ConfigFile.
+
+        The template uses `#TOKEN#` placeholders (e.g. `#CN#`, `#C#`) that the internal
+        Build-CsrConfig helper substitutes from parameter values. When editing by hand,
+        replace the placeholders with literal values.
+    .INPUTS
+        None.
+    .OUTPUTS
+        System.String[]. One element per line of the template, suitable for piping to Set-Content.
+    .EXAMPLE
+        PS C:\> Get-CSRTemplate | Set-Content -Path .\template.conf
+        Write the canonical template to disk for hand-editing.
+    .EXAMPLE
+        PS C:\> Get-CSRTemplate | Set-Content -Path .\template.conf
+        PS C:\> New-CertificateSigningRequest -OutputDirectory . -ConfigFile .\template.conf
+        Seed, edit, and use a custom config file.
+    .NOTES
+        Status: Stable
+        - Replaces the previously exported read-only `$CSR_Template` module variable.
+          The variable form caused a benign but noisy `Remove-Module` warning because
+          read-only variables cannot be torn down on module unload without -Force.
+    #>
+    [CmdletBinding()]
+    [OutputType([System.String[]])]
+    Param()
+    Process {
+        @(
+            '[req]'
+            'distinguished_name = req_distinguished_name'
+            'req_extensions = v3_req'
+            'default_bits = 4096'
+            'default_md = sha256'
+            'encrypt_key = no'
+            'prompt = no'
+            '[req_distinguished_name]'
+            'C = #C#'
+            'ST = #ST#'
+            'L = #L#'
+            'O = #O#'
+            'OU = #OU#'
+            'emailAddress = "#E#"'
+            'CN = #CN#'
+            '[v3_req]'
+            'keyUsage = keyEncipherment, dataEncipherment'
+            'extendedKeyUsage = serverAuth'
+            'subjectAltName = @alt_names'
+            '[alt_names]'
+        )
+    }
+}

--- a/Public/Get-CSRTemplate.ps1
+++ b/Public/Get-CSRTemplate.ps1
@@ -35,6 +35,9 @@ function Get-CSRTemplate {
     [CmdletBinding()]
     [OutputType([System.String[]])]
     Param()
+    Begin {
+        Write-Verbose -Message "Starting $($MyInvocation.Mycommand)"
+    }
     Process {
         @(
             '[req]'

--- a/Public/Get-CertificateData.ps1
+++ b/Public/Get-CertificateData.ps1
@@ -25,18 +25,7 @@ function Get-CertificateData {
     Process {
         # VERIFY SIGNED CERTIFICATE
         # openssl x509 -text -noout -in <Public_Key_Signed>.crt
-        $sslParams = @{
-            FilePath     = 'openssl' # .exe
-            ArgumentList = @(
-                'x509 -text -noout'
-                '-in {0}' -f $Path
-            )
-            Wait         = $true
-            NoNewWindow  = $true
-            PassThru     = $true
-        }
-        $proc = Start-Process @sslParams
-
-        if ($proc.ExitCode -NE 0) { Write-Error -Message ('openssl exited with code: {0}' -f $proc.ExitCode) }
+        $result = Invoke-OpenSsl -ArgumentList @('x509', '-text', '-noout', '-in', $Path)
+        $result.StdOut
     }
 }

--- a/Public/Get-CertificateData.ps1
+++ b/Public/Get-CertificateData.ps1
@@ -25,8 +25,7 @@ function Get-CertificateData {
         PS C:\> (Get-CertificateData -Path .\example.pem).Extensions | Where-Object { $_.Oid.Value -eq '2.5.29.17' } | ForEach-Object { $_.Format($true) }
         Print the Subject Alternative Name extension in human-readable form.
     .NOTES
-        Name:      Get-CertificateData
-        Author:    Justin Johns
+        Status: Beta
         - PEM files containing multiple concatenated certificates (e.g.
           fullchain.pem) are reduced to the FIRST certificate only. This
           matches the previous behavior of `openssl x509 -text -noout`.

--- a/Public/Get-CertificateData.ps1
+++ b/Public/Get-CertificateData.ps1
@@ -50,6 +50,9 @@ function Get-CertificateData {
             })]
         [System.String] $Path
     )
+    Begin {
+        Write-Verbose -Message "Starting $($MyInvocation.Mycommand)"
+    }
     Process {
         # Normalize PEM/CRT/CER input to DER bytes via openssl. We write to a
         # temp file rather than capturing DER bytes from stdout because the

--- a/Public/Get-CertificateData.ps1
+++ b/Public/Get-CertificateData.ps1
@@ -1,31 +1,73 @@
 function Get-CertificateData {
     <#
     .SYNOPSIS
-        Get x509 certificate details
+        Load an x509 certificate file as a .NET X509Certificate2 object.
     .DESCRIPTION
-        Get x509 certificate details
+        Reads a certificate file (.crt, .cer, or .pem) and returns the
+        corresponding System.Security.Cryptography.X509Certificates.X509Certificate2
+        instance so callers can inspect Subject, Issuer, validity dates,
+        extensions (incl. SAN), and the public key directly as typed members
+        rather than scraping openssl's human-readable text output.
+
+        openssl is invoked once to normalize the input encoding to DER bytes
+        regardless of source format; the certificate is then constructed from
+        those bytes via the standard .NET ctor.
     .PARAMETER Path
-        Path to x509 certificate file
+        Path to an x509 certificate file. Accepted extensions: .crt, .cer, .pem.
     .INPUTS
-        System.String.
+        System.String. Pipe a file path.
     .OUTPUTS
-        System.Object.
+        System.Security.Cryptography.X509Certificates.X509Certificate2.
     .EXAMPLE
-        PS C:\> <example usage>
-        Explanation of what the example does
+        PS C:\> Get-CertificateData -Path .\example.pem | Select-Object Subject, NotAfter, Thumbprint
+        Inspect summary fields.
+    .EXAMPLE
+        PS C:\> (Get-CertificateData -Path .\example.pem).Extensions | Where-Object { $_.Oid.Value -eq '2.5.29.17' } | ForEach-Object { $_.Format($true) }
+        Print the Subject Alternative Name extension in human-readable form.
     .NOTES
-        General notes
+        Name:      Get-CertificateData
+        Author:    Justin Johns
+        - PEM files containing multiple concatenated certificates (e.g.
+          fullchain.pem) are reduced to the FIRST certificate only. This
+          matches the previous behavior of `openssl x509 -text -noout`.
+        - openssl is used solely as a format-normalizer here; .NET's PEM
+          file loaders (X509Certificate2.CreateFromPemFile) require .NET 5+
+          and the module manifest declares PS 7.0 / .NET Core 3.1.
+        - BREAKING CHANGE from prior versions: this function returned the
+          raw multi-line openssl text dump. It now returns a typed cert
+          object. Pipe through `Format-List *` for a comparable human view.
     #>
+    [OutputType([System.Security.Cryptography.X509Certificates.X509Certificate2])]
     [CmdletBinding()]
     Param(
         [Parameter(Mandatory, ValueFromPipeline, HelpMessage = 'Path to x509 certificate file')]
-        [ValidateScript({ Test-Path -Path $_ -PathType Leaf -Include "*.crt", "*.cer", "*.pem" })]
+        [ValidateScript({
+                if (-not (Test-Path -Path $_ -PathType Leaf)) { Write-Error -Message "File not found: $_" -ErrorAction Stop }
+                $ext = [System.IO.Path]::GetExtension($_).ToLowerInvariant()
+                if ($ext -notin '.crt', '.cer', '.pem') {
+                    Write-Error -Message "Unsupported extension '$ext'. Expected .crt, .cer, or .pem." -ErrorAction Stop
+                }
+                $true
+            })]
         [System.String] $Path
     )
     Process {
-        # VERIFY SIGNED CERTIFICATE
-        # openssl x509 -text -noout -in <Public_Key_Signed>.crt
-        $result = Invoke-OpenSsl -ArgumentList @('x509', '-text', '-noout', '-in', $Path)
-        $result.StdOut
+        # Normalize PEM/CRT/CER input to DER bytes via openssl. We write to a
+        # temp file rather than capturing DER bytes from stdout because the
+        # Invoke-OpenSsl helper captures StdOut as a string, which would
+        # corrupt binary content.
+        $derPath = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ('pssl-cert-{0}.der' -f [System.Guid]::NewGuid().Guid.Substring(0, 8))
+        try {
+            $sslParams = @{
+                ArgumentList = @('x509', '-in', $Path, '-outform', 'DER', '-out', $derPath)
+            }
+            [System.Void] (Invoke-OpenSsl @sslParams)
+
+            $bytes = [System.IO.File]::ReadAllBytes($derPath)
+            [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($bytes)
+        }
+        finally {
+            if (Test-Path -Path $derPath) { Remove-Item -Path $derPath -Force -ErrorAction SilentlyContinue }
+        }
     }
 }

--- a/Public/Get-RemoteSSLCertificate.ps1
+++ b/Public/Get-RemoteSSLCertificate.ps1
@@ -24,6 +24,8 @@ function Get-RemoteSSLCertificate {
         PS C:\> Get-RemoteSSLCertificate -ComputerName $sites | Select-Object NotBefore, NotAfter, Subject
         The first command creates an array of multiple websites. The second commands tests each site and returns the expiry info
     .NOTES
+        Status: Stable
+
         SECURITY: This function intentionally bypasses TLS certificate
         validation. Its purpose is to retrieve the remote certificate -
         including expired, self-signed, hostname-mismatched, or otherwise
@@ -41,7 +43,8 @@ function Get-RemoteSSLCertificate {
         untrusted data. Do not chain it into trust decisions, pin it, or
         present it as proof of identity.
 
-        Original code from: https://gist.github.com/jstangroome/5945820
+        References:
+        https://gist.github.com/jstangroome/5945820
         https://docs.microsoft.com/en-us/archive/blogs/parallel_universe_-_ms_tech_blog/reading-a-certificate-off-a-remote-ssl-server-for-troubleshooting-with-powershell
     #>
     [CmdletBinding()]

--- a/Public/Get-RemoteSSLCertificate.ps1
+++ b/Public/Get-RemoteSSLCertificate.ps1
@@ -58,6 +58,9 @@ function Get-RemoteSSLCertificate {
         [ValidateRange(1, 65535)]
         [System.Int32] $Port = 443
     )
+    Begin {
+        Write-Verbose -Message "Starting $($MyInvocation.Mycommand)"
+    }
     Process {
 
         foreach ($cn in $ComputerName) {

--- a/Public/Get-RemoteSSLCertificate.ps1
+++ b/Public/Get-RemoteSSLCertificate.ps1
@@ -11,7 +11,9 @@ function Get-RemoteSSLCertificate {
     .INPUTS
         System.String.
     .OUTPUTS
-        System.Object.
+        System.Security.Cryptography.X509Certificates.X509Certificate2 - returned
+        for INSPECTION ONLY. Callers must not treat this certificate as having
+        been validated. See the SECURITY note below.
     .EXAMPLE
         --- Example 1: Get remote SSL certificate ---
         PS C:\> Get-RemoteSSLCertificate -ComputerName "www.microsoft.com"
@@ -22,11 +24,28 @@ function Get-RemoteSSLCertificate {
         PS C:\> Get-RemoteSSLCertificate -ComputerName $sites | Select-Object NotBefore, NotAfter, Subject
         The first command creates an array of multiple websites. The second commands tests each site and returns the expiry info
     .NOTES
-        General notes
+        SECURITY: This function intentionally bypasses TLS certificate
+        validation. Its purpose is to retrieve the remote certificate -
+        including expired, self-signed, hostname-mismatched, or otherwise
+        invalid certificates - for inspection and reporting. A validation
+        callback that returns $true unconditionally is REQUIRED for that to
+        work; refusing the connection on a validation failure would prevent
+        us from observing the very certificates an operator needs to see.
+
+        The bypass is scoped to the per-SslStream callback parameter and is
+        NOT installed on System.Net.ServicePointManager.ServerCertificateValidationCallback,
+        so it does not affect other TLS connections in the PowerShell
+        session or in the rest of the process.
+
+        Downstream callers MUST treat the returned X509Certificate2 as
+        untrusted data. Do not chain it into trust decisions, pin it, or
+        present it as proof of identity.
+
         Original code from: https://gist.github.com/jstangroome/5945820
         https://docs.microsoft.com/en-us/archive/blogs/parallel_universe_-_ms_tech_blog/reading-a-certificate-off-a-remote-ssl-server-for-troubleshooting-with-powershell
     #>
     [CmdletBinding()]
+    [OutputType([System.Security.Cryptography.X509Certificates.X509Certificate2])]
     Param(
         [Parameter(Mandatory, Position = 0, ValueFromPipeline, HelpMessage = 'Target System')]
         [ValidateNotNullOrEmpty()]
@@ -48,9 +67,14 @@ function Get-RemoteSSLCertificate {
                 $tcpClient.Connect($cn, $Port)
                 $tcpStream = $tcpClient.GetStream()
 
-                $callback = { <#param($sender, $cert, $chain, $errors)#> return $true }
+                # INTENTIONAL: accept any server certificate so we can inspect
+                # invalid/expired/self-signed ones. See SECURITY note in the
+                # function's help. This callback is bound to THIS SslStream
+                # only; it is never assigned to ServicePointManager, so it
+                # cannot affect other TLS connections in the session.
+                $inspectionOnlyValidationCallback = { <#param($sender, $cert, $chain, $errors)#> $true }
 
-                $sslStream = New-Object -TypeName System.Net.Security.SslStream -ArgumentList @($tcpStream, $true, $callback)
+                $sslStream = New-Object -TypeName System.Net.Security.SslStream -ArgumentList @($tcpStream, $true, $inspectionOnlyValidationCallback)
 
                 try {
                     #$sslStream.AuthenticateAsClient('')
@@ -62,6 +86,10 @@ function Get-RemoteSSLCertificate {
                 }
             }
             finally {
+                # NOTE: The SslStream was constructed with leaveInnerStreamOpen=$true,
+                # so it does NOT close $tcpStream. Disposing $tcpClient also
+                # disposes the NetworkStream it owns (returned by GetStream()),
+                # which covers the inner stream's lifetime here.
                 $tcpClient.Dispose()
             }
 

--- a/Public/New-CertificateSigningRequest.ps1
+++ b/Public/New-CertificateSigningRequest.ps1
@@ -53,8 +53,18 @@ function New-CertificateSigningRequest {
     [Alias('New-CSR')]
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High', DefaultParameterSetName = '__conf')]
     Param(
-        [Parameter(HelpMessage = 'Output directory for CSR and key file')]
-        [ValidateScript({ Test-Path -Path (Split-Path -Path $_) -PathType Container })]
+        [Parameter(HelpMessage = 'Output directory for generated files')]
+        [ValidateScript({
+                if (Test-Path -Path $_ -PathType Leaf) {
+                    Write-Error -Message "OutputDirectory '$_' exists but is a file, not a directory." -ErrorAction Stop
+                }
+                $parent = Split-Path -Path $_ -Parent
+                if ([string]::IsNullOrEmpty($parent)) { $parent = '.' }
+                if (-not (Test-Path -Path $parent -PathType Container)) {
+                    Write-Error -Message "Parent of OutputDirectory does not exist: $parent" -ErrorAction Stop
+                }
+                $true
+            })]
         [System.String] $OutputDirectory = "$HOME\Desktop",
 
         [Parameter(Mandatory, ParameterSetName = '__conf', HelpMessage = 'Path to configuration template')]
@@ -112,10 +122,7 @@ function New-CertificateSigningRequest {
         Write-Verbose -Message ('Parameter Set: {0}' -f $PSCmdlet.ParameterSetName)
 
         # GET OUTPUT DIRECTORY
-        if (-not (Test-Path -Path $OutputDirectory)) {
-            Write-Verbose -Message ('Creating new folder named: {0}' -f (Split-Path -Path $OutputDirectory -Leaf))
-            New-Item -Path $OutputDirectory -ItemType Directory | Out-Null
-        }
+        Initialize-OutputDirectory -Path $OutputDirectory
 
         # BUILD CSR BASED ON PARAMETER INPUT
         if ($PSCmdlet.ParameterSetName -eq '__input') {

--- a/Public/New-CertificateSigningRequest.ps1
+++ b/Public/New-CertificateSigningRequest.ps1
@@ -6,8 +6,6 @@ function New-CertificateSigningRequest {
         Generate new CSR and Private key file
     .PARAMETER OutputDirectory
         Output directory for CSR and key file
-    .PARAMETER Days
-        Validity period in days (default is 365)
     .PARAMETER ConfigFile
         Path to configuration template file
     .PARAMETER CommonName
@@ -36,7 +34,8 @@ function New-CertificateSigningRequest {
     .NOTES
         Name:      New-CertificateSigningRequest
         Author:    Justin Johns
-        Version:   0.2.1 | Last Edit: 2024-04-14
+        Version:   0.3.0 | Last Edit: 2026-05-22
+        - 0.3.0 - (2026-05-22) Removed -Days parameter (CSRs have no validity period; -days is silently ignored by openssl req without -x509). Validity is set by the issuing CA at signing time. (Breaking change.)
         - 0.2.1 - (2024-04-14) Fixed bug
         - 0.2.0 - (2024-03-08) Fixed SupportsShouldProcess, updated SAN input, renamed function
         - 0.1.1 - (2022-06-20) Added SupportsShouldProcess
@@ -52,10 +51,6 @@ function New-CertificateSigningRequest {
         [Parameter(HelpMessage = 'Output directory for CSR and key file')]
         [ValidateScript({ Test-Path -Path (Split-Path -Path $_) -PathType Container })]
         [System.String] $OutputDirectory = "$HOME\Desktop",
-
-        [Parameter(HelpMessage = 'Validity period in days (default is 365)')]
-        [ValidateRange(30, 3650)]
-        [System.String] $Days = 365,
 
         [Parameter(Mandatory, ParameterSetName = '__conf', HelpMessage = 'Path to configuration template')]
         [ValidateScript({ Test-Path -Path $_ -PathType Leaf -Include '*.conf' })]
@@ -178,10 +173,13 @@ function New-CertificateSigningRequest {
         # USING THE "-legacy" PARAMETER WILL MAINTAIN COMPATABILITY WITH CERTAIN SERVERS THAT DO NOT YET SUPPORT
         # THE LATEST CIPHERS OR PROTOCOLS
         # EXAMPLE> openssl pkcs12 -export -legacy -out example.pfx -inkey example.key -in example.crt
+        # NOTE: -days is intentionally NOT passed here. `openssl req` ignores it
+        # unless -x509 is also specified, and CSRs by design carry no validity
+        # period; the issuing CA sets validity at signing time.
         $sslParams = @{
             FilePath     = 'openssl' # .exe
             ArgumentList = @(
-                'req -new -nodes -days {0}' -f $Days
+                'req -new -nodes'
                 '-config {0}' -f $configPath
                 '-keyout {0}' -f (Join-Path -Path $OutputDirectory -ChildPath ('{0}_PRIVATE.key' -f $fileName))
                 '-out {0}' -f (Join-Path -Path $OutputDirectory -ChildPath ('{0}.csr' -f $fileName))

--- a/Public/New-CertificateSigningRequest.ps1
+++ b/Public/New-CertificateSigningRequest.ps1
@@ -29,7 +29,14 @@ function New-CertificateSigningRequest {
     .INPUTS
         None.
     .OUTPUTS
-        System.Object.
+        None. Writes three files into -OutputDirectory:
+          <CN>.csr          - the certificate signing request
+          <CN>_PRIVATE.key  - the matching private key (unencrypted)
+          <CN>.conf         - the openssl req config used to produce them,
+                              preserved as a reproducible record of the
+                              inputs. Only written when the cmdlet is invoked
+                              in the __input parameter set; -ConfigFile mode
+                              leaves the caller's file alone.
     .EXAMPLE
         PS C:\> New-CertificateSigningRequest -CommonName www.myDomain.com
         Creates a new CSR and private key for www.myDomain.com
@@ -112,65 +119,35 @@ function New-CertificateSigningRequest {
 
         # BUILD CSR BASED ON PARAMETER INPUT
         if ($PSCmdlet.ParameterSetName -eq '__input') {
-            # CREATE NEW LIST
-            $template = [System.Collections.ArrayList]::new()
+            # CN is the source of truth for the artifact basename, so derive it
+            # here rather than reading it back from the rendered .conf.
+            $fileName = $CommonName
 
-            # ADD TEMPLATE TO LIST
-            $template.AddRange($CSR_Template)
+            # THE CHARACTER "*" IS NOT VALID IN A WINDOWS FILENAME. REPLACE "*" WITH "STAR"
+            if ($fileName -match '\*') { $fileName = $fileName.Replace('*', 'star') }
 
-            # ADD SUBJECT ALTERNATIVE NAMES TO LIST
-            if ($PSBoundParameters.ContainsKey('SubjectAlternativeName')) {
-                # EVALUATE EACH SAN IN ARRAY
-                for ($i = 1; $i -lt ($SubjectAlternativeName.Count + 1); $i++) {
-                    # ADD SAN TO END OF COLLECTION
-                    $template.Add(('DNS.{0} = {1}' -f $i, $SubjectAlternativeName[$i - 1])) | Out-Null
-                }
+            # The .conf is intentionally preserved alongside the .csr / .key
+            # outputs as a reproducible record of the request inputs. Name it
+            # after the CN so all sibling artifacts group visually.
+            $configPath = Join-Path -Path $OutputDirectory -ChildPath ('{0}.conf' -f $fileName)
+
+            # DELEGATE TEMPLATE RENDERING TO PRIVATE HELPER
+            $buildParams = @{ CommonName = $CommonName; OutputPath = $configPath }
+            foreach ($key in 'Country', 'State', 'Locality', 'Organization', 'OrganizationalUnit', 'Email', 'SubjectAlternativeName') {
+                if ($PSBoundParameters.ContainsKey($key)) { $buildParams[$key] = $PSBoundParameters[$key] }
             }
-
-            # SET REPLACEMENT TOKENS
-            $tokenList = @{ CN = $CommonName }
-            if ($PSBoundParameters.ContainsKey('Country')) { $tokenList.Add('C', $Country) } else { $template.Remove('C = #C#') }
-            if ($PSBoundParameters.ContainsKey('State')) { $tokenList.Add('ST', $State) } else { $template.Remove('ST = #ST#') }
-            if ($PSBoundParameters.ContainsKey('Locality')) { $tokenList.Add('L', $Locality) } else { $template.Remove('L = #L#') }
-            if ($PSBoundParameters.ContainsKey('Organization')) { $tokenList.Add('O', $Organization) } else { $template.Remove('O = #O#') }
-            if ($PSBoundParameters.ContainsKey('OrganizationalUnit')) { $tokenList.Add('OU', $OrganizationalUnit) } else { $template.Remove('OU = #OU#') }
-            if ($PSBoundParameters.ContainsKey('Email')) { $tokenList.Add('E', $Email) } else { $template.Remove('emailAddress = "#E#"') }
-
-            # REMOVE SAN FROM TEMPLATE IF NOT PROVIDED
-            if (-Not $PSBoundParameters.ContainsKey('SubjectAlternativeName')) {
-                $template.Remove('[alt_names]')
-                $template.Remove('subjectAltName = @alt_names')
-            }
-
-            # REPLACE TOKENS IN TEMPLATE
-            foreach ($token in $tokenList.GetEnumerator()) {
-                $pattern = '#{0}#' -f $token.key
-                $template = $template -replace $pattern, $token.Value
-            }
-
-            # SHOW TEMPLATE
-            Write-Verbose -Message ("`n" + ($template -join "`n"))
-
-            # SET TEMPLATE FILE WITH NEW VALUES
-            $random = [System.IO.Path]::GetRandomFileName().Split('.')[0]
-            $configPath = Join-Path -Path $OutputDirectory -ChildPath ('csr_template_{0}.conf' -f $random)
-
-            # CREATE TEMPLATE FILE
-            Set-Content -Path $configPath -Value $template -Confirm:$false
-
-            # OUTPUT TEMPLATE PATH
-            Write-Verbose -Message ('Template file path: [{0}]' -f $configPath)
+            Build-CsrConfig @buildParams
         }
         else {
             $configPath = $ConfigFile
+
+            # SET FILE NAME (extract CN from caller-supplied config)
+            $selectPattern = Get-Content -Path $configPath | Select-String -Pattern '^CN = (.+)$'
+            $fileName = $selectPattern.Matches.Groups[1].Value
+
+            # THE CHARACTER "*" IS NOT VALID IN A WINDOWS FILENAME. REPLACE "*" WITH "STAR"
+            if ($fileName -match '\*') { $fileName = $fileName.Replace('*', 'star') }
         }
-
-        # SET FILE NAME
-        $selectPattern = Get-Content -Path $configPath | Select-String -Pattern '^CN = (.+)$'
-        $fileName = $selectPattern.Matches.Groups[1].Value
-
-        # THE CHARACTER "*" IS NOT VALID IN A WINDOWS FILENAME. REPLACE "*" WITH "STAR"
-        if ($fileName -match '\*') { $fileName = $fileName.Replace('*', 'star') }
         Write-Verbose -Message ('New file name: {0}' -f $fileName)
 
         # SET OPENSSL ARGUMENTS

--- a/Public/New-CertificateSigningRequest.ps1
+++ b/Public/New-CertificateSigningRequest.ps1
@@ -41,14 +41,7 @@ function New-CertificateSigningRequest {
         PS C:\> New-CertificateSigningRequest -CommonName www.myDomain.com
         Creates a new CSR and private key for www.myDomain.com
     .NOTES
-        Name:      New-CertificateSigningRequest
-        Author:    Justin Johns
-        Version:   0.3.0 | Last Edit: 2026-05-22
-        - Version history is captured in repository commit history
-        General notes
-        Example commands
-        openssl req -newkey rsa:2048 -sha256 -keyout PRIVATEKEY.key -out MYCSR.csr -subj "/C=US/ST=CA/L=Redlands/O=Esri/CN=myDomain.com"
-        openssl req -new -newkey rsa:2048 -nodes -sha256 -out company_san.csr -keyout company_san.key -config req.conf
+        Status: Stable
     #>
     [Alias('New-CSR')]
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High', DefaultParameterSetName = '__conf')]

--- a/Public/New-CertificateSigningRequest.ps1
+++ b/Public/New-CertificateSigningRequest.ps1
@@ -24,6 +24,8 @@ function New-CertificateSigningRequest {
         Email Address
     .PARAMETER SubjectAlternativeName
         Subject Alternative Name (SAN)
+    .PARAMETER KeySize
+        RSA key size in bits (2048, 3072, or 4096; default is 4096). Emitted explicitly to openssl so the result is deterministic regardless of the config template contents.
     .INPUTS
         None.
     .OUTPUTS
@@ -35,7 +37,7 @@ function New-CertificateSigningRequest {
         Name:      New-CertificateSigningRequest
         Author:    Justin Johns
         Version:   0.3.0 | Last Edit: 2026-05-22
-        - 0.3.0 - (2026-05-22) Removed -Days parameter (CSRs have no validity period; -days is silently ignored by openssl req without -x509). Validity is set by the issuing CA at signing time. (Breaking change.)
+        - 0.3.0 - (2026-05-22) Removed -Days parameter (CSRs have no validity period; -days is silently ignored by openssl req without -x509). Validity is set by the issuing CA at signing time. (Breaking change.) Added -KeySize parameter (default 4096) and emit -newkey/-sha256 explicitly so output is deterministic regardless of config file.
         - 0.2.1 - (2024-04-14) Fixed bug
         - 0.2.0 - (2024-03-08) Fixed SupportsShouldProcess, updated SAN input, renamed function
         - 0.1.1 - (2022-06-20) Added SupportsShouldProcess
@@ -93,7 +95,11 @@ function New-CertificateSigningRequest {
         [Parameter(ParameterSetName = '__input', HelpMessage = 'Subject Alternative Name (SAN)')]
         [Alias('SAN')]
         [ValidatePattern('^[\w\.-]+\.(com|org|gov|info)$')]
-        [System.String[]] $SubjectAlternativeName
+        [System.String[]] $SubjectAlternativeName,
+
+        [Parameter(HelpMessage = 'RSA key size in bits (default 4096)')]
+        [ValidateSet(2048, 3072, 4096)]
+        [System.Int32] $KeySize = 4096
     )
     Begin {
         Write-Verbose -Message "Starting $($MyInvocation.Mycommand)"
@@ -176,10 +182,12 @@ function New-CertificateSigningRequest {
         # NOTE: -days is intentionally NOT passed here. `openssl req` ignores it
         # unless -x509 is also specified, and CSRs by design carry no validity
         # period; the issuing CA sets validity at signing time.
+        # -newkey/-sha256 are emitted explicitly so the result is deterministic
+        # even when a custom -ConfigFile omits default_bits/default_md.
         $sslParams = @{
             FilePath     = 'openssl' # .exe
             ArgumentList = @(
-                'req -new -nodes'
+                'req -new -nodes -newkey rsa:{0} -sha256' -f $KeySize
                 '-config {0}' -f $configPath
                 '-keyout {0}' -f (Join-Path -Path $OutputDirectory -ChildPath ('{0}_PRIVATE.key' -f $fileName))
                 '-out {0}' -f (Join-Path -Path $OutputDirectory -ChildPath ('{0}.csr' -f $fileName))

--- a/Public/New-CertificateSigningRequest.ps1
+++ b/Public/New-CertificateSigningRequest.ps1
@@ -9,7 +9,13 @@ function New-CertificateSigningRequest {
     .PARAMETER ConfigFile
         Path to configuration template file
     .PARAMETER CommonName
-        Common Name (CN)
+        Common Name (CN). Restricted by ValidatePattern to the TLD allow-list
+        (.com/.org/.gov/.info) and does NOT accept a leading wildcard
+        (e.g. `*.example.com`). This is a deliberate security/compliance
+        posture: wildcard certificates are discouraged. To issue a wildcard
+        CSR, use the `-ConfigFile` parameter set with a caller-supplied
+        openssl `req` config (the `__conf` branch is wildcard-aware and
+        sanitizes the `*` out of the artifact filenames).
     .PARAMETER Country
         Country Name (C)
     .PARAMETER State
@@ -42,6 +48,11 @@ function New-CertificateSigningRequest {
         Creates a new CSR and private key for www.myDomain.com
     .NOTES
         Status: Stable
+
+        - Wildcard CNs (`*.example.com`) are rejected by the `CommonName`
+          ValidatePattern and so are unreachable via the `__input`
+          parameter set. Wildcard CSRs remain supported via `-ConfigFile`.
+          See the `CommonName` parameter help for the rationale.
     #>
     [Alias('New-CSR')]
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High', DefaultParameterSetName = '__conf')]
@@ -113,7 +124,13 @@ function New-CertificateSigningRequest {
             # here rather than reading it back from the rendered .conf.
             $fileName = $CommonName
 
-            # THE CHARACTER "*" IS NOT VALID IN A WINDOWS FILENAME. REPLACE "*" WITH "STAR"
+            # `*` is not a valid Windows filename character. The CommonName
+            # ValidatePattern currently rejects wildcards, so this rewrite is
+            # unreachable from the `__input` branch today; it is kept
+            # intentionally so that relaxing the regex in the future (when
+            # wildcard CSRs are again permitted by policy) does not require
+            # a parallel filename-sanitization change. The `__conf` branch
+            # below uses the same rewrite and IS reachable for wildcards.
             if ($fileName -match '\*') { $fileName = $fileName.Replace('*', 'star') }
 
             # The .conf is intentionally preserved alongside the .csr / .key

--- a/Public/New-CertificateSigningRequest.ps1
+++ b/Public/New-CertificateSigningRequest.ps1
@@ -60,7 +60,9 @@ function New-CertificateSigningRequest {
 
         [Parameter(Mandatory, ParameterSetName = '__input', HelpMessage = 'Common Name (CN)')]
         [Alias('CN')]
-        [ValidatePattern('^[\w\.-]+\.(com|org|gov)$')]
+        # TLD allow-list reflects the domain scope this module is deployed against.
+        # Update both CommonName and SubjectAlternativeName together if the policy changes.
+        [ValidatePattern('^[\w\.-]+\.(com|org|gov|info)$')]
         [System.String] $CommonName,
 
         [Parameter(ParameterSetName = '__input', HelpMessage = 'Country Name (C)')]
@@ -94,6 +96,7 @@ function New-CertificateSigningRequest {
 
         [Parameter(ParameterSetName = '__input', HelpMessage = 'Subject Alternative Name (SAN)')]
         [Alias('SAN')]
+        # TLD allow-list must match CommonName above.
         [ValidatePattern('^[\w\.-]+\.(com|org|gov|info)$')]
         [System.String[]] $SubjectAlternativeName,
 

--- a/Public/New-CertificateSigningRequest.ps1
+++ b/Public/New-CertificateSigningRequest.ps1
@@ -37,11 +37,7 @@ function New-CertificateSigningRequest {
         Name:      New-CertificateSigningRequest
         Author:    Justin Johns
         Version:   0.3.0 | Last Edit: 2026-05-22
-        - 0.3.0 - (2026-05-22) Removed -Days parameter (CSRs have no validity period; -days is silently ignored by openssl req without -x509). Validity is set by the issuing CA at signing time. (Breaking change.) Added -KeySize parameter (default 4096) and emit -newkey/-sha256 explicitly so output is deterministic regardless of config file.
-        - 0.2.1 - (2024-04-14) Fixed bug
-        - 0.2.0 - (2024-03-08) Fixed SupportsShouldProcess, updated SAN input, renamed function
-        - 0.1.1 - (2022-06-20) Added SupportsShouldProcess
-        - 0.1.0 - Initial versions
+        - Version history is captured in repository commit history
         General notes
         Example commands
         openssl req -newkey rsa:2048 -sha256 -keyout PRIVATEKEY.key -out MYCSR.csr -subj "/C=US/ST=CA/L=Redlands/O=Esri/CN=myDomain.com"

--- a/Public/New-CertificateSigningRequest.ps1
+++ b/Public/New-CertificateSigningRequest.ps1
@@ -54,17 +54,7 @@ function New-CertificateSigningRequest {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High', DefaultParameterSetName = '__conf')]
     Param(
         [Parameter(HelpMessage = 'Output directory for generated files')]
-        [ValidateScript({
-                if (Test-Path -Path $_ -PathType Leaf) {
-                    Write-Error -Message "OutputDirectory '$_' exists but is a file, not a directory." -ErrorAction Stop
-                }
-                $parent = Split-Path -Path $_ -Parent
-                if ([string]::IsNullOrEmpty($parent)) { $parent = '.' }
-                if (-not (Test-Path -Path $parent -PathType Container)) {
-                    Write-Error -Message "Parent of OutputDirectory does not exist: $parent" -ErrorAction Stop
-                }
-                $true
-            })]
+        [ValidateScript({ Test-OutputDirectoryPath -Path $_ })]
         [System.String] $OutputDirectory = "$HOME\Desktop",
 
         [Parameter(Mandatory, ParameterSetName = '__conf', HelpMessage = 'Path to configuration template')]

--- a/Public/New-CertificateSigningRequest.ps1
+++ b/Public/New-CertificateSigningRequest.ps1
@@ -173,7 +173,7 @@ function New-CertificateSigningRequest {
         if ($fileName -match '\*') { $fileName = $fileName.Replace('*', 'star') }
         Write-Verbose -Message ('New file name: {0}' -f $fileName)
 
-        # SET OPENSSL PARAMETERS
+        # SET OPENSSL ARGUMENTS
         # openssl req -new -newkey rsa:2048 -nodes -sha256 -out company_san.csr -keyout company_san.key -config req.conf
         # USING THE "-legacy" PARAMETER WILL MAINTAIN COMPATABILITY WITH CERTAIN SERVERS THAT DO NOT YET SUPPORT
         # THE LATEST CIPHERS OR PROTOCOLS
@@ -183,30 +183,22 @@ function New-CertificateSigningRequest {
         # period; the issuing CA sets validity at signing time.
         # -newkey/-sha256 are emitted explicitly so the result is deterministic
         # even when a custom -ConfigFile omits default_bits/default_md.
-        $sslParams = @{
-            FilePath     = 'openssl' # .exe
-            ArgumentList = @(
-                'req -new -nodes -newkey rsa:{0} -sha256' -f $KeySize
-                '-config {0}' -f $configPath
-                '-keyout {0}' -f (Join-Path -Path $OutputDirectory -ChildPath ('{0}_PRIVATE.key' -f $fileName))
-                '-out {0}' -f (Join-Path -Path $OutputDirectory -ChildPath ('{0}.csr' -f $fileName))
-            )
-            Wait         = $true
-            NoNewWindow  = $true
-            PassThru     = $true
-        }
+        $keyoutPath = Join-Path -Path $OutputDirectory -ChildPath ('{0}_PRIVATE.key' -f $fileName)
+        $csrOutPath = Join-Path -Path $OutputDirectory -ChildPath ('{0}.csr' -f $fileName)
+        $opensslArgs = @(
+            'req', '-new', '-nodes',
+            '-newkey', ('rsa:{0}' -f $KeySize),
+            '-sha256',
+            '-config', $configPath,
+            '-keyout', $keyoutPath,
+            '-out', $csrOutPath
+        )
 
         # SHOULD PROCESS
         if ($PSCmdlet.ShouldProcess($OutputDirectory, "Create Files")) {
 
             # INVOKE OPENSSL
-            $proc = Start-Process @sslParams
-
-            # CHECK FOR ERRORS
-            if ($proc.ExitCode -NE 0) {
-                # OUTPUT ERROR
-                Write-Error -Message ('openssl failed with exit code: {0}' -f $proc.ExitCode)
-            }
+            [System.Void] (Invoke-OpenSsl -ArgumentList $opensslArgs)
         }
     }
 }

--- a/Public/New-SelfSignedCertificate.ps1
+++ b/Public/New-SelfSignedCertificate.ps1
@@ -26,6 +26,8 @@ function New-SelfSignedCertificate {
         Email Address
     .PARAMETER SubjectAlternativeName
         Subject Alternative Name (SAN)
+    .PARAMETER KeySize
+        RSA key size in bits (2048, 3072, or 4096; default is 4096). Emitted explicitly to openssl so the result is deterministic regardless of the config template contents.
     .INPUTS
         None.
     .OUTPUTS
@@ -36,9 +38,9 @@ function New-SelfSignedCertificate {
     .NOTES
         Name:      New-SelfSignedCertificate
         Author:    Justin Johns
-        Version:   0.2.1 | Last Edit: 2025-08-28
-        Comments: <Comment(s)>
-        General notes
+        Version:   0.3.0 | Last Edit: 2026-05-22
+        - 0.3.0 - (2026-05-22) Added -KeySize parameter (default 4096) and emit -newkey/-sha256 explicitly so output is deterministic regardless of config file.
+        - 0.2.1 - (2025-08-28) Previous version
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High', DefaultParameterSetName = '__conf')]
     Param(
@@ -91,7 +93,11 @@ function New-SelfSignedCertificate {
         [Parameter(ParameterSetName = '__input', HelpMessage = 'Subject Alternative Name (SAN)')]
         [Alias('SAN')]
         [ValidatePattern('^[\w\.-]+\.(com|org|gov|info)$')]
-        [System.String[]] $SubjectAlternativeName
+        [System.String[]] $SubjectAlternativeName,
+
+        [Parameter(HelpMessage = 'RSA key size in bits (default 4096)')]
+        [ValidateSet(2048, 3072, 4096)]
+        [System.Int32] $KeySize = 4096
     )
     Begin {
         Write-Verbose -Message "Starting $($MyInvocation.Mycommand)"
@@ -167,15 +173,13 @@ function New-SelfSignedCertificate {
         Write-Verbose -Message ('New file name: {0}' -f $fileName)
 
         # SET OPENSSL PARAMETERS
-        # openssl req -new -newkey rsa:2048 -nodes -sha256 -out company_san.csr -keyout company_san.key -config req.conf
-        # USING THE "-legacy" PARAMETER WILL MAINTAIN COMPATABILITY WITH CERTAIN SERVERS THAT DO NOT YET SUPPORT
-        # THE LATEST CIPHERS OR PROTOCOLS
-        # EXAMPLE> openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -sha256 -days 365
-        # -newkey rsa:4096 and -sha256 are in the default template
+        # openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -sha256 -days 365
+        # -newkey/-sha256 are emitted explicitly so output is deterministic
+        # even when a custom -ConfigFile omits default_bits/default_md.
         $sslParams = @{
             FilePath     = 'openssl'
             ArgumentList = @(
-                'req -new -x509 -nodes -days {0}' -f $Days
+                'req -new -x509 -nodes -newkey rsa:{0} -sha256 -days {1}' -f $KeySize, $Days
                 '-config {0}' -f $configPath
                 '-keyout {0}' -f (Join-Path -Path $OutputDirectory -ChildPath ('{0}_PRIVATE.key' -f $fileName))
                 '-out {0}' -f (Join-Path -Path $OutputDirectory -ChildPath ('{0}.pem' -f $fileName))

--- a/Public/New-SelfSignedCertificate.ps1
+++ b/Public/New-SelfSignedCertificate.ps1
@@ -51,17 +51,7 @@ function New-SelfSignedCertificate {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High', DefaultParameterSetName = '__conf')]
     Param(
         [Parameter(HelpMessage = 'Output directory for generated files')]
-        [ValidateScript({
-                if (Test-Path -Path $_ -PathType Leaf) {
-                    Write-Error -Message "OutputDirectory '$_' exists but is a file, not a directory." -ErrorAction Stop
-                }
-                $parent = Split-Path -Path $_ -Parent
-                if ([string]::IsNullOrEmpty($parent)) { $parent = '.' }
-                if (-not (Test-Path -Path $parent -PathType Container)) {
-                    Write-Error -Message "Parent of OutputDirectory does not exist: $parent" -ErrorAction Stop
-                }
-                $true
-            })]
+        [ValidateScript({ Test-OutputDirectoryPath -Path $_ })]
         [System.String] $OutputDirectory = "$HOME\Desktop",
 
         [Parameter(HelpMessage = 'Validity period in days (default is 365)')]

--- a/Public/New-SelfSignedCertificate.ps1
+++ b/Public/New-SelfSignedCertificate.ps1
@@ -39,8 +39,7 @@ function New-SelfSignedCertificate {
         Name:      New-SelfSignedCertificate
         Author:    Justin Johns
         Version:   0.3.0 | Last Edit: 2026-05-22
-        - 0.3.0 - (2026-05-22) Added -KeySize parameter (default 4096) and emit -newkey/-sha256 explicitly so output is deterministic regardless of config file.
-        - 0.2.1 - (2025-08-28) Previous version
+        - Version history is captured in repository commit history
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High', DefaultParameterSetName = '__conf')]
     Param(

--- a/Public/New-SelfSignedCertificate.ps1
+++ b/Public/New-SelfSignedCertificate.ps1
@@ -50,8 +50,18 @@ function New-SelfSignedCertificate {
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High', DefaultParameterSetName = '__conf')]
     Param(
-        [Parameter(HelpMessage = 'Output directory for CSR and key file')]
-        [ValidateScript({ Test-Path -Path (Split-Path -Path $_) -PathType Container })]
+        [Parameter(HelpMessage = 'Output directory for generated files')]
+        [ValidateScript({
+                if (Test-Path -Path $_ -PathType Leaf) {
+                    Write-Error -Message "OutputDirectory '$_' exists but is a file, not a directory." -ErrorAction Stop
+                }
+                $parent = Split-Path -Path $_ -Parent
+                if ([string]::IsNullOrEmpty($parent)) { $parent = '.' }
+                if (-not (Test-Path -Path $parent -PathType Container)) {
+                    Write-Error -Message "Parent of OutputDirectory does not exist: $parent" -ErrorAction Stop
+                }
+                $true
+            })]
         [System.String] $OutputDirectory = "$HOME\Desktop",
 
         [Parameter(HelpMessage = 'Validity period in days (default is 365)')]
@@ -110,10 +120,7 @@ function New-SelfSignedCertificate {
         Write-Verbose -Message ('Parameter Set: {0}' -f $PSCmdlet.ParameterSetName)
 
         # CREATE OUTPUT DIRECTORY
-        if (-not (Test-Path -Path $OutputDirectory)) {
-            Write-Verbose -Message ('Creating new folder named: {0}' -f (Split-Path -Path $OutputDirectory -Leaf))
-            New-Item -Path $OutputDirectory -ItemType Directory | Out-Null
-        }
+        Initialize-OutputDirectory -Path $OutputDirectory
 
         # CREATE TEMPLATE FILE
         if ($PSCmdlet.ParameterSetName -eq '__input') {

--- a/Public/New-SelfSignedCertificate.ps1
+++ b/Public/New-SelfSignedCertificate.ps1
@@ -43,10 +43,7 @@ function New-SelfSignedCertificate {
         PS C:\> New-SelfSignedCertificate -CommonName myDomain.com
         Generates a new self-signed certificate for myDomain.com
     .NOTES
-        Name:      New-SelfSignedCertificate
-        Author:    Justin Johns
-        Version:   0.3.0 | Last Edit: 2026-05-22
-        - Version history is captured in repository commit history
+        Status: Stable
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High', DefaultParameterSetName = '__conf')]
     Param(

--- a/Public/New-SelfSignedCertificate.ps1
+++ b/Public/New-SelfSignedCertificate.ps1
@@ -171,34 +171,27 @@ function New-SelfSignedCertificate {
         if ($fileName -match '\*') { $fileName = $fileName.Replace('*', 'star') }
         Write-Verbose -Message ('New file name: {0}' -f $fileName)
 
-        # SET OPENSSL PARAMETERS
+        # SET OPENSSL ARGUMENTS
         # openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -sha256 -days 365
         # -newkey/-sha256 are emitted explicitly so output is deterministic
         # even when a custom -ConfigFile omits default_bits/default_md.
-        $sslParams = @{
-            FilePath     = 'openssl'
-            ArgumentList = @(
-                'req -new -x509 -nodes -newkey rsa:{0} -sha256 -days {1}' -f $KeySize, $Days
-                '-config {0}' -f $configPath
-                '-keyout {0}' -f (Join-Path -Path $OutputDirectory -ChildPath ('{0}_PRIVATE.key' -f $fileName))
-                '-out {0}' -f (Join-Path -Path $OutputDirectory -ChildPath ('{0}.pem' -f $fileName))
-            )
-            Wait         = $true
-            NoNewWindow  = $true
-            PassThru     = $true
-        }
+        $keyoutPath = Join-Path -Path $OutputDirectory -ChildPath ('{0}_PRIVATE.key' -f $fileName)
+        $certOutPath = Join-Path -Path $OutputDirectory -ChildPath ('{0}.pem' -f $fileName)
+        $opensslArgs = @(
+            'req', '-new', '-x509', '-nodes',
+            '-newkey', ('rsa:{0}' -f $KeySize),
+            '-sha256',
+            '-days', $Days.ToString(),
+            '-config', $configPath,
+            '-keyout', $keyoutPath,
+            '-out', $certOutPath
+        )
 
         # SHOULD PROCESS
         if ($PSCmdlet.ShouldProcess($OutputDirectory, "Create Files")) {
 
             # GENERATE CERTIFICATE FILES USING OPENSSL
-            $proc = Start-Process @sslParams
-
-            # CHECK FOR ERRORS
-            if ($proc.ExitCode -NE 0) {
-                # OUTPUT ERROR
-                Write-Error -Message ('openssl failed with exit code: {0}' -f $proc.ExitCode)
-            }
+            [System.Void] (Invoke-OpenSsl -ArgumentList $opensslArgs)
         }
     }
 }

--- a/Public/New-SelfSignedCertificate.ps1
+++ b/Public/New-SelfSignedCertificate.ps1
@@ -31,7 +31,14 @@ function New-SelfSignedCertificate {
     .INPUTS
         None.
     .OUTPUTS
-        System.Object.
+        None. Writes three files into -OutputDirectory:
+          <CN>.pem          - the self-signed certificate
+          <CN>_PRIVATE.key  - the matching private key (unencrypted)
+          <CN>.conf         - the openssl req config used to produce them,
+                              preserved as a reproducible record of the
+                              inputs. Only written when the cmdlet is invoked
+                              in the __input parameter set; -ConfigFile mode
+                              leaves the caller's file alone.
     .EXAMPLE
         PS C:\> New-SelfSignedCertificate -CommonName myDomain.com
         Generates a new self-signed certificate for myDomain.com
@@ -110,65 +117,35 @@ function New-SelfSignedCertificate {
 
         # CREATE TEMPLATE FILE
         if ($PSCmdlet.ParameterSetName -eq '__input') {
-            # CREATE NEW LIST
-            $template = [System.Collections.ArrayList]::new()
+            # CN is the source of truth for the artifact basename, so derive it
+            # here rather than reading it back from the rendered .conf.
+            $fileName = $CommonName
 
-            # ADD TEMPLATE TO LIST
-            $template.AddRange($CSR_Template)
+            # THE CHARACTER "*" IS NOT VALID IN A WINDOWS FILENAME. REPLACE "*" WITH "STAR"
+            if ($fileName -match '\*') { $fileName = $fileName.Replace('*', 'star') }
 
-            # ADD SUBJECT ALTERNATIVE NAMES TO LIST
-            if ($PSBoundParameters.ContainsKey('SubjectAlternativeName')) {
-                # EVALUATE EACH SAN IN ARRAY
-                for ($i = 1; $i -lt ($SubjectAlternativeName.Count + 1); $i++) {
-                    # ADD SAN TO END OF COLLECTION
-                    $template.Add(('DNS.{0} = {1}' -f $i, $SubjectAlternativeName[$i - 1])) | Out-Null
-                }
+            # The .conf is intentionally preserved alongside the .pem / .key
+            # outputs as a reproducible record of the request inputs. Name it
+            # after the CN so all sibling artifacts group visually.
+            $configPath = Join-Path -Path $OutputDirectory -ChildPath ('{0}.conf' -f $fileName)
+
+            # DELEGATE TEMPLATE RENDERING TO PRIVATE HELPER
+            $buildParams = @{ CommonName = $CommonName; OutputPath = $configPath }
+            foreach ($key in 'Country', 'State', 'Locality', 'Organization', 'OrganizationalUnit', 'Email', 'SubjectAlternativeName') {
+                if ($PSBoundParameters.ContainsKey($key)) { $buildParams[$key] = $PSBoundParameters[$key] }
             }
-
-            # SET REPLACEMENT TOKENS
-            $tokenList = @{ CN = $CommonName }
-            if ($PSBoundParameters.ContainsKey('Country')) { $tokenList.Add('C', $Country) } else { $template.Remove('C = #C#') }
-            if ($PSBoundParameters.ContainsKey('State')) { $tokenList.Add('ST', $State) } else { $template.Remove('ST = #ST#') }
-            if ($PSBoundParameters.ContainsKey('Locality')) { $tokenList.Add('L', $Locality) } else { $template.Remove('L = #L#') }
-            if ($PSBoundParameters.ContainsKey('Organization')) { $tokenList.Add('O', $Organization) } else { $template.Remove('O = #O#') }
-            if ($PSBoundParameters.ContainsKey('OrganizationalUnit')) { $tokenList.Add('OU', $OrganizationalUnit) } else { $template.Remove('OU = #OU#') }
-            if ($PSBoundParameters.ContainsKey('Email')) { $tokenList.Add('E', $Email) } else { $template.Remove('emailAddress = "#E#"') }
-
-            # REMOVE SAN FROM TEMPLATE IF NOT PROVIDED
-            if (-Not $PSBoundParameters.ContainsKey('SubjectAlternativeName')) {
-                $template.Remove('[alt_names]')
-                $template.Remove('subjectAltName = @alt_names')
-            }
-
-            # REPLACE TOKENS
-            foreach ($token in $tokenList.GetEnumerator()) {
-                $pattern = '#{0}#' -f $token.key
-                $template = $template -replace $pattern, $token.Value
-            }
-
-            # SHOW TEMPLATE
-            Write-Verbose -Message ("`n" + ($template -join "`n"))
-
-            # SET TEMPLATE FILE PATH
-            $random = [System.IO.Path]::GetRandomFileName().Split('.')[0]
-            $configPath = Join-Path -Path $OutputDirectory -ChildPath ('template_{0}.conf' -f $random)
-
-            # CREATE TEMPLATE FILE
-            Set-Content -Path $configPath -Value $template -Confirm:$false
-
-            # OUTPUT TEMPLATE PATH
-            Write-Verbose -Message ('Template file path: [{0}]' -f $configPath)
+            Build-CsrConfig @buildParams
         }
         else {
             $configPath = $ConfigFile
+
+            # SET FILE NAME (extract CN from caller-supplied config)
+            $selectPattern = Get-Content -Path $configPath | Select-String -Pattern '^CN = (.+)$'
+            $fileName = $selectPattern.Matches.Groups[1].Value
+
+            # THE CHARACTER "*" IS NOT VALID IN A WINDOWS FILENAME. REPLACE "*" WITH "STAR"
+            if ($fileName -match '\*') { $fileName = $fileName.Replace('*', 'star') }
         }
-
-        # SET FILE NAME
-        $selectPattern = Get-Content -Path $configPath | Select-String -Pattern '^CN = (.+)$'
-        $fileName = $selectPattern.Matches.Groups[1].Value
-
-        # THE CHARACTER "*" IS NOT VALID IN A WINDOWS FILENAME. REPLACE "*" WITH "STAR"
-        if ($fileName -match '\*') { $fileName = $fileName.Replace('*', 'star') }
         Write-Verbose -Message ('New file name: {0}' -f $fileName)
 
         # SET OPENSSL ARGUMENTS

--- a/Public/Test-Cipher.ps1
+++ b/Public/Test-Cipher.ps1
@@ -23,10 +23,8 @@ function Test-Cipher {
         ------------ ---- ------                       --------- -----
         myServer.com  443 ECDHE-RSA-AES128-GCM-SHA256       True
     .NOTES
-        Name:     Test-Cipher
-        Author:   Justin Johns
-        Version:  0.2.0 | Last Edit: 2026-05-22
-        - Version history is captured in repository commit history
+        Status: Stable
+        References:
         https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#describe-ssl-policies
     #>
     [CmdletBinding()]

--- a/Public/Test-Cipher.ps1
+++ b/Public/Test-Cipher.ps1
@@ -52,22 +52,18 @@ function Test-Cipher {
         Write-Verbose -Message "Starting $($MyInvocation.Mycommand)"
     }
     Process {
-        # SET SSL PARAMETERS
-        $sslParams = @{
-            FilePath = 'openssl'
-            ArgumentList = @(
-                # openssl s_client -cipher '<CIPHER>' -connect <IP/HostName>:<Port>
-                's_client -cipher {0} -connect {1}:{2}' -f $Cipher, $ComputerName, $Port
-            )
-            Wait = $true; NoNewWindow = $true; PassThru = $true
+        # openssl s_client -cipher '<CIPHER>' -connect <IP/HostName>:<Port>
+        # A non-zero exit means the server rejected the cipher; preserve the
+        # existing non-terminating Write-Error behavior. Item 3b will rework
+        # this to return a structured object.
+        $endpoint = '{0}:{1}' -f $ComputerName, $Port
+        $result = Invoke-OpenSsl -ArgumentList @('s_client', '-cipher', $Cipher, '-connect', $endpoint) -IgnoreExitCode
+
+        if ($result.ExitCode -ne 0) {
+            Write-Error -Message ('openssl failed with exit code {0}: {1}' -f $result.ExitCode, $result.StdErr.Trim())
         }
-
-        # GENERATE CERTIFICATE FILES USING OPENSSL
-        $proc = Start-Process @sslParams
-
-        # VALIDATE RESPONSE
-        if ($proc.ExitCode -NE 0) {
-            Write-Error -Message ('openssl failed with exit code: {0}' -f $proc.ExitCode)
+        else {
+            $result.StdOut
         }
     }
 }

--- a/Public/Test-Cipher.ps1
+++ b/Public/Test-Cipher.ps1
@@ -21,7 +21,7 @@ function Test-Cipher {
         Name:     Test-Cipher
         Author:   Justin Johns
         Version:  0.1.0 | Last Edit: 2023-12-21
-        - 0.1.0 - Initial version
+        - Version history is captured in repository commit history
         Comments:
         https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#describe-ssl-policies
     #>

--- a/Public/Test-Cipher.ps1
+++ b/Public/Test-Cipher.ps1
@@ -36,7 +36,16 @@ function Test-Cipher {
         [System.Int32] $Port = 443,
 
         [Parameter(Mandatory = $true, Position = 2, HelpMessage = 'Cipher')]
-        [ValidateScript({ $_ -in ((openssl ciphers) -split ':') })]
+        [ValidateScript({
+            if (-not (Get-Command -Name 'openssl' -CommandType Application -ErrorAction SilentlyContinue)) {
+                Write-Error -Message "'openssl' was not found on PATH; cannot validate cipher." -Category ObjectNotFound -ErrorAction Stop
+            }
+            $supported = (& openssl ciphers 2>$null) -split ':'
+            if ($_ -notin $supported) {
+                Write-Error -Message ("Cipher '{0}' is not in the local openssl cipher list. Run 'openssl ciphers' to view supported values." -f $_) -Category InvalidArgument -ErrorAction Stop
+            }
+            $true
+        })]
         [System.String] $Cipher
     )
     Begin {

--- a/Public/Test-Cipher.ps1
+++ b/Public/Test-Cipher.ps1
@@ -1,9 +1,11 @@
 function Test-Cipher {
     <#
     .SYNOPSIS
-        Test cipher suites
+        Test cipher suite support against a remote endpoint
     .DESCRIPTION
-        Test cipher suites
+        Probes a host:port with `openssl s_client` requesting a specific
+        cipher, and returns a structured result indicating whether the
+        handshake succeeded.
     .PARAMETER ComputerName
         Target Computer System
     .PARAMETER Port
@@ -13,19 +15,22 @@ function Test-Cipher {
     .INPUTS
         None.
     .OUTPUTS
-        None.
+        PSCustomObject with ComputerName, Port, Cipher, Supported, Error.
     .EXAMPLE
         PS C:\> Test-Cipher -ComputerName myServer.com -Port 443 -Cipher 'ECDHE-RSA-AES128-GCM-SHA256'
-        Uses openssl to test connecting to myServer.com over port 443 using the cipher 'ECDHE-RSA-AES128-GCM-SHA256'
+
+        ComputerName Port Cipher                       Supported Error
+        ------------ ---- ------                       --------- -----
+        myServer.com  443 ECDHE-RSA-AES128-GCM-SHA256       True
     .NOTES
         Name:     Test-Cipher
         Author:   Justin Johns
-        Version:  0.1.0 | Last Edit: 2023-12-21
+        Version:  0.2.0 | Last Edit: 2026-05-22
         - Version history is captured in repository commit history
-        Comments:
         https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#describe-ssl-policies
     #>
     [CmdletBinding()]
+    [OutputType([System.Management.Automation.PSCustomObject])]
     Param(
         [Parameter(Mandatory = $true, Position = 0, HelpMessage = 'Target System')]
         [ValidateNotNullOrEmpty()]
@@ -52,18 +57,19 @@ function Test-Cipher {
         Write-Verbose -Message "Starting $($MyInvocation.Mycommand)"
     }
     Process {
-        # openssl s_client -cipher '<CIPHER>' -connect <IP/HostName>:<Port>
-        # A non-zero exit means the server rejected the cipher; preserve the
-        # existing non-terminating Write-Error behavior. Item 3b will rework
-        # this to return a structured object.
+        # openssl s_client -cipher '<CIPHER>' -connect <host:port>
+        # Non-zero exit means the server rejected the cipher; use
+        # -IgnoreExitCode so we receive the result object instead of a
+        # terminating error and can encode the outcome as Supported=$false.
         $endpoint = '{0}:{1}' -f $ComputerName, $Port
         $result = Invoke-OpenSsl -ArgumentList @('s_client', '-cipher', $Cipher, '-connect', $endpoint) -IgnoreExitCode
 
-        if ($result.ExitCode -ne 0) {
-            Write-Error -Message ('openssl failed with exit code {0}: {1}' -f $result.ExitCode, $result.StdErr.Trim())
-        }
-        else {
-            $result.StdOut
+        [PSCustomObject] @{
+            ComputerName = $ComputerName
+            Port         = $Port
+            Cipher       = $Cipher
+            Supported    = ($result.ExitCode -eq 0)
+            Error        = if ($result.ExitCode -eq 0) { $null } else { $result.StdErr.Trim() }
         }
     }
 }

--- a/Public/Test-PrivateKeyCertMatch.ps1
+++ b/Public/Test-PrivateKeyCertMatch.ps1
@@ -76,7 +76,7 @@ function Test-PrivateKeyCertMatch {
         $keyProc = Start-Process @keyParams
 
         # VALIDATE KEY EXTRACTION
-        if ($keyProc.ExitCode -NE 0) {
+        if ($keyProc.ExitCode -ne 0) {
             # CLEANUP TEMPORARY FILES
             Remove-Item -Path $keyTempFile, $certTempFile -Force -ErrorAction SilentlyContinue
             Write-Error -Message ('openssl failed to extract public key from private key with exit code: {0}' -f $keyProc.ExitCode) -ErrorAction Stop
@@ -101,7 +101,7 @@ function Test-PrivateKeyCertMatch {
         $certProc = Start-Process @certParams
 
         # VALIDATE CERTIFICATE EXTRACTION
-        if ($certProc.ExitCode -NE 0) {
+        if ($certProc.ExitCode -ne 0) {
             # CLEANUP TEMPORARY FILES
             Remove-Item -Path $keyTempFile, $certTempFile -Force -ErrorAction SilentlyContinue
             Write-Error -Message ('openssl failed to extract public key from certificate with exit code: {0}' -f $certProc.ExitCode) -ErrorAction Stop

--- a/Public/Test-PrivateKeyCertMatch.ps1
+++ b/Public/Test-PrivateKeyCertMatch.ps1
@@ -38,7 +38,8 @@ function Test-PrivateKeyCertMatch {
         PS C:> Test-PrivateKeyCertMatch -PrivateKeyPath "$outDir\${cn}_PRIVATE.key" -CertificatePath "$outDir\$otherCn.pem"
         Generates two self-signed certificates and tests the private key of the first against both. Only the first test should return True.
     .NOTES
-        General notes
+        Status: Stable
+        References:
         https://man.openbsd.org/openssl.1
     #>
     [CmdletBinding()]

--- a/Public/Test-Protocol.ps1
+++ b/Public/Test-Protocol.ps1
@@ -21,7 +21,7 @@ function Test-Protocol {
         Name:     Test-Protocol
         Author:   Justin Johns
         Version:  0.1.0 | Last Edit: 2023-12-21
-        - 0.1.0 - Initial version
+        - Version history is captured in repository commit history
         Comments:
     #>
     [CmdletBinding()]

--- a/Public/Test-Protocol.ps1
+++ b/Public/Test-Protocol.ps1
@@ -1,9 +1,11 @@
 function Test-Protocol {
     <#
     .SYNOPSIS
-        Test TLS protocol
+        Test TLS protocol support against a remote endpoint
     .DESCRIPTION
-        Test TLS protocol
+        Probes a host:port with `openssl s_client` requesting a specific TLS
+        protocol version, and returns a structured result indicating whether
+        the handshake succeeded.
     .PARAMETER ComputerName
         Target Computer System
     .PARAMETER Port
@@ -13,18 +15,21 @@ function Test-Protocol {
     .INPUTS
         None.
     .OUTPUTS
-        None.
+        PSCustomObject with ComputerName, Port, Protocol, Supported, Error.
     .EXAMPLE
-        PS C:\> Test-Protocol -ComputerName mySever.com -Port 443 -Protocl 'TLS 1.2'
-        Uses openssl to test connecting to myServer.com over port 443 using TLS 1.2
+        PS C:\> Test-Protocol -ComputerName mySever.com -Port 443 -Protocol 'TLS 1.2'
+
+        ComputerName Port Protocol Supported Error
+        ------------ ---- -------- --------- -----
+        mySever.com   443 TLS 1.2       True
     .NOTES
         Name:     Test-Protocol
         Author:   Justin Johns
-        Version:  0.1.0 | Last Edit: 2023-12-21
+        Version:  0.2.0 | Last Edit: 2026-05-22
         - Version history is captured in repository commit history
-        Comments:
     #>
     [CmdletBinding()]
+    [OutputType([System.Management.Automation.PSCustomObject])]
     Param(
         [Parameter(Mandatory = $true, Position = 0, HelpMessage = 'Target System')]
         [ValidateNotNullOrEmpty()]
@@ -41,7 +46,7 @@ function Test-Protocol {
     Begin {
         Write-Verbose -Message "Starting $($MyInvocation.Mycommand)"
 
-        # SET HASH TABLE FOR PROTOCOL
+        # MAP FRIENDLY PROTOCOL NAMES TO openssl s_client SWITCHES
         $protoHash = @{
             'TLS 1.0' = 'tls1'
             'TLS 1.1' = 'tls1_1'
@@ -50,19 +55,25 @@ function Test-Protocol {
         }
     }
     Process {
-        # openssl.exe s_client -connect 10.0.0.24:3389 -tls1
-        # A non-zero exit means the server rejected the protocol; preserve the
-        # existing non-terminating Write-Error behavior. Item 3b will rework
-        # this to return a structured object.
+        # openssl.exe s_client -connect <host:port> -<protocol-switch>
+        # Non-zero exit means the server rejected the protocol; use
+        # -IgnoreExitCode so we receive the result object instead of a
+        # terminating error and can encode the outcome as Supported=$false.
         $endpoint = '{0}:{1}' -f $ComputerName, $Port
         $protoSwitch = '-{0}' -f $protoHash[$Protocol]
         $result = Invoke-OpenSsl -ArgumentList @('s_client', '-connect', $endpoint, $protoSwitch) -IgnoreExitCode
 
-        if ($result.ExitCode -ne 0) {
-            Write-Error -Message ('openssl failed with exit code {0}: {1}' -f $result.ExitCode, $result.StdErr.Trim())
-        }
-        else {
-            $result.StdOut
+        # On a successful handshake openssl writes the negotiated session to
+        # stdout and exits with code 0; on rejection it writes a diagnostic
+        # to stderr ("handshake failure", "no protocols available", etc.) and
+        # exits non-zero. Trim stderr for readability and only surface it on
+        # the failure path.
+        [PSCustomObject] @{
+            ComputerName = $ComputerName
+            Port         = $Port
+            Protocol     = $Protocol
+            Supported    = ($result.ExitCode -eq 0)
+            Error        = if ($result.ExitCode -eq 0) { $null } else { $result.StdErr.Trim() }
         }
     }
 }

--- a/Public/Test-Protocol.ps1
+++ b/Public/Test-Protocol.ps1
@@ -23,10 +23,7 @@ function Test-Protocol {
         ------------ ---- -------- --------- -----
         mySever.com   443 TLS 1.2       True
     .NOTES
-        Name:     Test-Protocol
-        Author:   Justin Johns
-        Version:  0.2.0 | Last Edit: 2026-05-22
-        - Version history is captured in repository commit history
+        Status: Stable
     #>
     [CmdletBinding()]
     [OutputType([System.Management.Automation.PSCustomObject])]

--- a/Public/Test-Protocol.ps1
+++ b/Public/Test-Protocol.ps1
@@ -50,22 +50,19 @@ function Test-Protocol {
         }
     }
     Process {
-        # SET SSL PARAMETERS
-        $sslParams = @{
-            FilePath     = 'openssl'
-            ArgumentList = @(
-                #openssl.exe s_client -connect 10.0.0.24:3389 -tls1
-                's_client -connect {0}:{1} -{2}' -f $ComputerName, $Port, $protoHash[$Protocol]
-            )
-            Wait = $true; NoNewWindow = $true; PassThru = $true
+        # openssl.exe s_client -connect 10.0.0.24:3389 -tls1
+        # A non-zero exit means the server rejected the protocol; preserve the
+        # existing non-terminating Write-Error behavior. Item 3b will rework
+        # this to return a structured object.
+        $endpoint = '{0}:{1}' -f $ComputerName, $Port
+        $protoSwitch = '-{0}' -f $protoHash[$Protocol]
+        $result = Invoke-OpenSsl -ArgumentList @('s_client', '-connect', $endpoint, $protoSwitch) -IgnoreExitCode
+
+        if ($result.ExitCode -ne 0) {
+            Write-Error -Message ('openssl failed with exit code {0}: {1}' -f $result.ExitCode, $result.StdErr.Trim())
         }
-
-        # GENERATE CERTIFICATE FILES USING OPENSSL
-        $proc = Start-Process @sslParams
-
-        # VALIDATE RESPONSE
-        if ($proc.ExitCode -NE 0) {
-            Write-Error -Message ('openssl failed with exit code: {0}' -f $proc.ExitCode)
+        else {
+            $result.StdOut
         }
     }
 }

--- a/Public/Test-SSLProtocol.ps1
+++ b/Public/Test-SSLProtocol.ps1
@@ -54,8 +54,42 @@ function Test-SSLProtocol {
                 $netStream = New-Object System.Net.Sockets.NetworkStream($socket, $true)
                 $sslStream = New-Object System.Net.Security.SslStream($netStream, $true)
                 $sslStream.AuthenticateAsClient($ComputerName, $null, $pn, $false )
-                $remoteCertificate = [System.Security.Cryptography.X509Certificates.X509Certificate2] $sslStream.RemoteCertificate
-                $protocolStatus['KeyLength'] = $remoteCertificate.PublicKey.Key.KeySize
+                # Build a real X509Certificate2 from the raw cert bytes. The cast
+                # [X509Certificate2] $sslStream.RemoteCertificate is not a true upcast
+                # (RemoteCertificate is typed as X509Certificate) and would leave the
+                # algorithm-specific Get*PublicKey() methods unavailable.
+                $remoteCertificate = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($sslStream.RemoteCertificate)
+
+                # Resolve the public key size via algorithm-specific accessors on the
+                # PublicKey object. The legacy PublicKey.Key getter is deprecated and
+                # throws NotSupportedException for ECDSA/DSA certs in .NET 5+, which
+                # previously caused the whole protocol probe to fall into the catch
+                # block for non-RSA endpoints. The Get*PublicKey() methods on
+                # X509Certificate2 itself are C# extension methods (not visible to
+                # PowerShell instance-method dispatch), so we call them on PublicKey,
+                # where they are real instance methods since .NET 5.
+                $keySize = $null
+                $pk = $remoteCertificate.PublicKey
+                $rsa = $pk.GetRSAPublicKey()
+                if ($rsa) {
+                    $keySize = $rsa.KeySize
+                    $rsa.Dispose()
+                }
+                else {
+                    $ecdsa = $pk.GetECDsaPublicKey()
+                    if ($ecdsa) {
+                        $keySize = $ecdsa.KeySize
+                        $ecdsa.Dispose()
+                    }
+                    else {
+                        $dsa = $pk.GetDSAPublicKey()
+                        if ($dsa) {
+                            $keySize = $dsa.KeySize
+                            $dsa.Dispose()
+                        }
+                    }
+                }
+                $protocolStatus['KeyLength'] = $keySize
                 $protocolStatus['SignatureAlgorithm'] = $remoteCertificate.SignatureAlgorithm.FriendlyName
                 $protocolStatus['KeyExchange'] = $sslStream.KeyExchangeAlgorithm
                 $protocolStatus['HashAlgorithm'] = $sslStream.HashAlgorithm

--- a/Public/Test-SSLProtocol.ps1
+++ b/Public/Test-SSLProtocol.ps1
@@ -47,10 +47,10 @@ function Test-SSLProtocol {
 
         foreach ($pn in $protoNames) {
 
-            $socket = New-Object System.Net.Sockets.Socket([System.Net.Sockets.SocketType]::Stream, [System.Net.Sockets.ProtocolType]::Tcp)
-            $socket.Connect($ComputerName, $Port)
-
+            $socket = $null; $netStream = $null; $sslStream = $null
             try {
+                $socket = New-Object System.Net.Sockets.Socket([System.Net.Sockets.SocketType]::Stream, [System.Net.Sockets.ProtocolType]::Tcp)
+                $socket.Connect($ComputerName, $Port)
                 $netStream = New-Object System.Net.Sockets.NetworkStream($socket, $true)
                 $sslStream = New-Object System.Net.Security.SslStream($netStream, $true)
                 $sslStream.AuthenticateAsClient($ComputerName, $null, $pn, $false )
@@ -64,10 +64,15 @@ function Test-SSLProtocol {
             }
             catch {
                 $protocolStatus.Add($pn, $false)
+                Write-Verbose -Message ('Protocol {0} unavailable: {1}' -f $pn, $_.Exception.Message)
             }
             finally {
-                $socket.Close()
-                $sslStream.Close()
+                # Dispose in reverse construction order. NetworkStream owns the socket
+                # (ownsSocket: $true) once constructed, so only close the socket directly
+                # when the stream wrapper was never created.
+                if ($sslStream)  { $sslStream.Dispose() }
+                if ($netStream)  { $netStream.Dispose() }
+                elseif ($socket) { $socket.Close() }
             }
         }
 

--- a/Public/Test-SSLProtocol.ps1
+++ b/Public/Test-SSLProtocol.ps1
@@ -32,6 +32,8 @@ function Test-SSLProtocol {
         [System.Int32] $Port = 443
     )
     Begin {
+        Write-Verbose -Message "Starting $($MyInvocation.Mycommand)"
+
         $protoProps = [System.Security.Authentication.SslProtocols] | Get-Member -Static -MemberType Property
         $protoNames = ($protoProps | Where-Object Name -notin 'Default', 'None').Name
     }

--- a/Public/Test-SSLProtocol.ps1
+++ b/Public/Test-SSLProtocol.ps1
@@ -16,8 +16,8 @@ function Test-SSLProtocol {
         PS C:\> Test-SSLProtocl -ComputerName 'www.mysite.com'
         Tests www.mysite.com for access using various SSL/TLS protocols
     .NOTES
-        General notes
-        Original code from:
+        Status: Stable
+        References:
         https://dscottraynsford.wordpress.com/2016/12/24/test-website-ssl-certificates-continuously-with-powershell-and-pester/
         https://www.sysadmins.lv/blog-en/test-web-server-ssltls-protocol-support-with-powershell.aspx
     #>

--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ into your user-scope modules folder, and copies the example scripts to
 Run `Get-Help <Cmdlet-Name> -Full` for parameter details and examples on any
 of the above.
 
+Every cmdlet carries a `Status` marker (`Stable`, `Beta`, `Experimental`, or
+`Deprecated`) in its `.NOTES` block. Most exports are `Stable`; three are
+currently `Beta` and may change shape based on feedback:
+`Export-CertificateData`, `Get-CertificateData`, `Get-CSRData`. Run
+`Get-Help <Cmdlet-Name> -Full` to see the marker for any cmdlet.
+
 ## Usage
 
 ### Generate a CSR and private key

--- a/README.md
+++ b/README.md
@@ -53,8 +53,10 @@ git clone https://github.com/johnsarie27/PS.SSL.git (Join-Path $modulesPath 'PS.
 Import-Module PS.SSL
 ```
 
-The `examples/setup.ps1` helper does the same end-to-end on Windows
-(download zip → expand → unblock → open a sample script). See
+The `examples/setup.ps1` helper does the same end-to-end on Windows,
+macOS, and Linux (installs openssl via winget/brew/apt-get/dnf, clones
+into your user-scope modules folder, and copies the example scripts to
+`~/ps.ssl-examples`). See
 [CONTRIBUTING.md](CONTRIBUTING.md) for the local development workflow
 (psake build, Pester tests, PSScriptAnalyzer).
 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,25 @@
 # PS.SSL
 
-Module wraps Openssl for creating SSL certificate signing requests and other common tasks
+[![validate](https://github.com/johnsarie27/PS.SSL/actions/workflows/validate.yml/badge.svg)](https://github.com/johnsarie27/PS.SSL/actions/workflows/validate.yml)
+[![GitHub release](https://img.shields.io/github/v/release/johnsarie27/PS.SSL?display_name=tag&sort=semver)](https://github.com/johnsarie27/PS.SSL/releases)
+[![License](https://img.shields.io/github/license/johnsarie27/PS.SSL)](LICENSE)
+[![PowerShell](https://img.shields.io/badge/PowerShell-7.0%2B-5391FE?logo=powershell&logoColor=white)](https://learn.microsoft.com/powershell/)
+
+PowerShell module that wraps `openssl` for creating and inspecting SSL/TLS
+certificates, certificate signing requests (CSRs), private keys, PFX bundles,
+and for probing the cipher and protocol support of remote endpoints.
+
+Requires PowerShell 7.0+ and `openssl` on `PATH`.
 
 ## Prerequisites
 
 This module requires Openssl.
-To install Openssl on Windows using either winget or chocolatey, use the code below.
+To install Openssl on Windows using winget, use the code below.
 
 ```pwsh
-# USING CHOCOLATEY
-choco install openssl
-
-# USING WINGET
 winget install --Id ShiningLight.OpenSSL
 
-# OR
+# OR (smaller footprint)
 winget install --Id ShiningLight.OpenSSL.Light
 ```
 
@@ -34,6 +39,127 @@ sudo apt update
 sudo apt install openssl -y
 ```
 
+## Installation
+
+This module is not yet published to the PowerShell Gallery. Install from
+source:
+
+```pwsh
+# Clone into your user modules folder
+$modulesPath = ($env:PSModulePath -split [System.IO.Path]::PathSeparator)[0]
+git clone https://github.com/johnsarie27/PS.SSL.git (Join-Path $modulesPath 'PS.SSL')
+
+# Import
+Import-Module PS.SSL
+```
+
+The `examples/setup.ps1` helper does the same end-to-end on Windows
+(download zip → expand → unblock → open a sample script). See
+[CONTRIBUTING.md](CONTRIBUTING.md) for the local development workflow
+(psake build, Pester tests, PSScriptAnalyzer).
+
+## Cmdlets
+
+| Cmdlet | Purpose |
+|---|---|
+| **CSR, key, and certificate generation** | |
+| `New-CertificateSigningRequest` (alias `New-CSR`) | Generate a CSR and matching private key. Renders an openssl `req` config from parameters or accepts a caller-supplied config file. |
+| `New-SelfSignedCertificate` | Generate a self-signed certificate, private key, and config in one shot. |
+| `Get-CSRTemplate` | Return the canonical `openssl req` config template as `[string[]]`. Useful as a starting point for hand-crafted configs. |
+| **Inspection and parsing** | |
+| `Get-CertificateData` | Parse a `.pem` certificate into a `[System.Security.Cryptography.X509Certificates.X509Certificate2]` object via openssl-normalized DER bytes. |
+| `Get-CSRData` | Parse a `.csr` file into a structured object (`Subject`, `PublicKeyAlgorithm`, `PublicKeyBits`, `SignatureAlgorithm`, `SubjectAlternativeName`, `Verified`, plus the full openssl text in `Raw`). |
+| `Get-RemoteSSLCertificate` | Retrieve the leaf certificate served by a remote host (HTTPS or any TLS-enabled service). |
+| `ConvertFrom-PKCS7` | Extract the certificates inside a PKCS#7 (`.p7b`) bundle. |
+| `ConvertTo-PEM` | Normalize certificate content to PEM (`-----BEGIN CERTIFICATE-----`) format. |
+| **Export and packaging** | |
+| `Export-Base64Certificate` | Write a byte array as a PEM-formatted `.crt` file (RFC 7468, 64-char line width). |
+| `Export-CertificateData` | Extract the certificate, intermediate chain, or private key block out of a combined `.pem` bundle into separate files. |
+| `Export-PFX` | Bundle a certificate plus private key into a PFX (`.pfx`) file. Passwords are handed to openssl via the child-process environment, not the command line. |
+| **Verification** | |
+| `Test-PrivateKeyCertMatch` | Confirm that a private key matches a certificate by comparing the SHA-256 hashes of their public keys. |
+| **Remote server probing** (openssl `s_client` under the hood) | |
+| `Test-Cipher` | Test whether a remote host accepts a specific cipher suite. |
+| `Test-Protocol` | Test whether a remote host supports a specific TLS/SSL protocol version. |
+| `Test-SSLProtocol` | Higher-level scan: enumerate the protocol versions a remote host supports. |
+
+Run `Get-Help <Cmdlet-Name> -Full` for parameter details and examples on any
+of the above.
+
+## Usage
+
+### Generate a CSR and private key
+
+```pwsh
+$csrParams = @{
+    CommonName             = 'www.example.com'
+    Organization           = 'Example Inc'
+    Country                = 'US'
+    State                  = 'WA'
+    Locality               = 'Seattle'
+    SubjectAlternativeName = 'example.com', 'api.example.com'
+    OutputDirectory        = 'C:\certs'
+}
+New-CertificateSigningRequest @csrParams
+```
+
+Writes three files into `C:\certs`:
+
+- `www.example.com.csr` &mdash; the certificate signing request
+- `www.example.com_PRIVATE.key` &mdash; the matching RSA private key (unencrypted)
+- `www.example.com.conf` &mdash; the openssl config used, preserved as a reproducible record
+
+### Retrieve and inspect a remote certificate
+
+```pwsh
+$cert = Get-RemoteSSLCertificate -ComputerName 'github.com'
+
+$cert | Select-Object Subject, Issuer, NotBefore, NotAfter, Thumbprint
+$cert.DnsNameList
+
+# Save a copy as a base64-encoded .crt
+Export-Base64Certificate -ByteArray $cert.RawData -Path "$HOME\github.com.crt"
+```
+
+### Bundle a certificate and key into a PFX
+
+```pwsh
+$password = Read-Host -AsSecureString -Prompt 'PFX password'
+
+$pfxParams = @{
+    KeyPath         = '.\www.example.com_PRIVATE.key'
+    SignedCSRPath   = '.\www.example.com.crt'
+    RootCAPath      = '.\root-ca.crt'
+    OutputDirectory = 'C:\certs'
+    Password        = $password
+}
+Export-PFX @pfxParams
+```
+
+Writes `C:\certs\www.example.com.pfx` (the basename is derived from
+`-SignedCSRPath`). The password is delivered to `openssl pkcs12` via a
+per-child-process environment variable (`-passout env:VAR`) rather than the
+command line, so it never appears in process listings, EDR telemetry, or
+audit logs.
+
+### Probe a remote server's TLS support
+
+```pwsh
+Test-SSLProtocol -ComputerName 'example.com'
+```
+
+Returns a table showing which TLS protocol versions the host accepts. For
+finer-grained probes use `Test-Protocol` (one version at a time) or
+`Test-Cipher` (a specific cipher suite).
+
 ## Updates
 
-Please see release information for updates
+Please see release information for updates.
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## License
+
+MIT. See [LICENSE](LICENSE).

--- a/Tests/Common/Help.Tests.ps1
+++ b/Tests/Common/Help.Tests.ps1
@@ -7,6 +7,16 @@ BeforeDiscovery {
     $Cmdlets = Get-Command -Module $env:BHProjectName -CommandType 'Cmdlet', 'Function' -ErrorAction 'Stop'
 }
 
+# Guard against a vacuously-green run when the module exports zero commands
+# (e.g., Public/ got emptied or the manifest's FunctionsToExport drifted).
+# Without this, the data-driven 'Describe -ForEach $Cmdlets' below produces
+# zero It blocks and the suite passes.
+Describe 'Module surface' {
+    It 'Exports at least one command' {
+        $Cmdlets.Count | Should -BeGreaterThan 0
+    }
+}
+
 Describe '<_> help' -ForEach $Cmdlets {
     BeforeDiscovery {
         $Common = 'ProgressAction', 'Debug', 'ErrorAction', 'ErrorVariable', 'InformationAction', 'InformationVariable', 'OutBuffer', 'OutVariable', 'PipelineVariable', 'Verbose', 'WarningAction', 'WarningVariable', 'Confirm', 'Whatif'

--- a/Tests/Common/Help.Tests.ps1
+++ b/Tests/Common/Help.Tests.ps1
@@ -11,9 +11,17 @@ BeforeDiscovery {
 # (e.g., Public/ got emptied or the manifest's FunctionsToExport drifted).
 # Without this, the data-driven 'Describe -ForEach $Cmdlets' below produces
 # zero It blocks and the suite passes.
+# NOTE: In Pester 5, BeforeDiscovery state does not flow to It blocks, so the
+# module must be re-imported in BeforeAll for the run-time scope.
 Describe 'Module surface' {
+    BeforeAll {
+        if (-not (Get-Module -Name $env:BHProjectName)) {
+            Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+        }
+    }
     It 'Exports at least one command' {
-        $Cmdlets.Count | Should -BeGreaterThan 0
+        $exported = Get-Command -Module $env:BHProjectName -CommandType 'Cmdlet', 'Function' -ErrorAction 'Stop'
+        $exported.Count | Should -BeGreaterThan 0
     }
 }
 

--- a/Tests/Integration/PS.SSL.Integration.Tests.ps1
+++ b/Tests/Integration/PS.SSL.Integration.Tests.ps1
@@ -12,6 +12,10 @@ BeforeAll {
     else {
         Join-Path -Path $PSScriptRoot -ChildPath '..\..\PS.SSL.psd1' | Resolve-Path | Select-Object -ExpandProperty Path
     }
+    # See New-CertificateSigningRequest.Tests.ps1 for rationale: `-Force` does
+    # not displace a module loaded from a different absolute path, so remove
+    # all existing PS.SSL copies before importing to keep the session clean.
+    Get-Module -Name 'PS.SSL' -All | Remove-Module -Force -ErrorAction SilentlyContinue
     Import-Module -Name $manifestPath -Force
 }
 

--- a/Tests/Integration/PS.SSL.Integration.Tests.ps1
+++ b/Tests/Integration/PS.SSL.Integration.Tests.ps1
@@ -1,0 +1,88 @@
+BeforeDiscovery {
+    # Gate the entire Describe on openssl availability so CI runners that
+    # lack openssl skip cleanly rather than failing. Use a script-scoped
+    # variable so it survives Discovery -> Run transitions.
+    $script:HasOpenSsl = [bool] (Get-Command -Name 'openssl' -CommandType Application -ErrorAction SilentlyContinue)
+}
+
+BeforeAll {
+    $manifestPath = if ($env:BHPSModuleManifest) {
+        $env:BHPSModuleManifest
+    }
+    else {
+        Join-Path -Path $PSScriptRoot -ChildPath '..\..\PS.SSL.psd1' | Resolve-Path | Select-Object -ExpandProperty Path
+    }
+    Import-Module -Name $manifestPath -Force
+}
+
+Describe 'PS.SSL integration (real openssl)' -Tag 'Integration' -Skip:(-not $script:HasOpenSsl) {
+
+    Context 'New-CertificateSigningRequest end-to-end' {
+
+        It 'Produces a CSR and matching private key that openssl can verify' {
+            $cn  = 'integration.example.com'
+            $dir = Join-Path $TestDrive 'csr'
+            New-Item -Path $dir -ItemType Directory -Force | Out-Null
+
+            New-CertificateSigningRequest -CommonName $cn -OutputDirectory $dir -KeySize 2048 -Confirm:$false
+
+            $csrPath = Join-Path $dir "$cn.csr"
+            $keyPath = Join-Path $dir "${cn}_PRIVATE.key"
+
+            Test-Path -Path $csrPath -PathType Leaf | Should -BeTrue
+            Test-Path -Path $keyPath -PathType Leaf | Should -BeTrue
+
+            # `openssl req -verify` self-checks the CSR signature against its
+            # embedded public key - the strongest single-shot proof that the
+            # generated CSR is well-formed and internally consistent.
+            $null = & openssl req -in $csrPath -noout -verify 2>&1
+            $LASTEXITCODE | Should -Be 0
+        }
+    }
+
+    Context 'Test-PrivateKeyCertMatch' {
+
+        BeforeAll {
+            $script:cnA  = 'match-a.example.com'
+            $script:cnB  = 'match-b.example.com'
+            $script:dir  = Join-Path $TestDrive 'match'
+            New-Item -Path $script:dir -ItemType Directory -Force | Out-Null
+
+            New-SelfSignedCertificate -CommonName $script:cnA -OutputDirectory $script:dir -Confirm:$false
+            New-SelfSignedCertificate -CommonName $script:cnB -OutputDirectory $script:dir -Confirm:$false
+
+            $script:keyA  = Join-Path $script:dir "$($script:cnA)_PRIVATE.key"
+            $script:certA = Join-Path $script:dir "$($script:cnA).pem"
+            $script:certB = Join-Path $script:dir "$($script:cnB).pem"
+        }
+
+        It 'Returns $true for a matching key/cert pair' {
+            Test-PrivateKeyCertMatch -PrivateKeyPath $script:keyA -CertificatePath $script:certA | Should -BeTrue
+        }
+
+        It 'Returns $false for a mismatched key/cert pair' {
+            Test-PrivateKeyCertMatch -PrivateKeyPath $script:keyA -CertificatePath $script:certB | Should -BeFalse
+        }
+    }
+
+    Context 'Export-Base64Certificate against real DER bytes' {
+
+        It 'Writes a PEM that openssl can re-parse as a valid x509 certificate' {
+            $cn  = 'pem.example.com'
+            $dir = Join-Path $TestDrive 'pem'
+            New-Item -Path $dir -ItemType Directory -Force | Out-Null
+
+            New-SelfSignedCertificate -CommonName $cn -OutputDirectory $dir -Confirm:$false
+            $srcPem = Join-Path $dir "$cn.pem"
+
+            # Load the cert and round-trip its DER bytes through
+            # Export-Base64Certificate, then ask openssl to parse the result.
+            $cert    = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($srcPem)
+            $outPath = Join-Path $dir 'roundtrip.crt'
+            Export-Base64Certificate -ByteArray $cert.RawData -Path $outPath
+
+            $null = & openssl x509 -in $outPath -noout -text 2>&1
+            $LASTEXITCODE | Should -Be 0
+        }
+    }
+}

--- a/Tests/Integration/PS.SSL.Network.Integration.Tests.ps1
+++ b/Tests/Integration/PS.SSL.Network.Integration.Tests.ps1
@@ -98,4 +98,56 @@ Describe 'PS.SSL network integration (real TLS endpoint)' -Tag 'Integration', 'N
             $result.ComputerName | Should -Be $script:NetworkTarget
         }
     }
+
+    Context 'Get-RemoteSSLCertificate against badssl.com' {
+
+        BeforeAll {
+            $script:remoteCert = Get-RemoteSSLCertificate -ComputerName $script:NetworkTarget -Port $script:NetworkPort
+        }
+
+        It 'Returns an X509Certificate2' {
+            $script:remoteCert | Should -BeOfType ([System.Security.Cryptography.X509Certificates.X509Certificate2])
+        }
+
+        It 'Populates Subject with a non-empty string' {
+            $script:remoteCert.Subject | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Returns a currently-valid certificate (NotAfter is in the future)' {
+            $script:remoteCert.NotAfter | Should -BeOfType ([datetime])
+            $script:remoteCert.NotAfter | Should -BeGreaterThan (Get-Date)
+        }
+
+        It 'Accepts -ComputerName from the pipeline' {
+            $result = $script:NetworkTarget | Get-RemoteSSLCertificate -Port $script:NetworkPort
+            $result         | Should -Not -BeNullOrEmpty
+            $result.Subject | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Returns one certificate per host when given multiple -ComputerName values' {
+            $hosts = @($script:NetworkTarget, $script:NetworkTarget)
+            $results = Get-RemoteSSLCertificate -ComputerName $hosts -Port $script:NetworkPort
+            $results.Count | Should -Be 2
+            $results | ForEach-Object {
+                $_ | Should -BeOfType ([System.Security.Cryptography.X509Certificates.X509Certificate2])
+            }
+        }
+    }
+
+    Context 'Get-RemoteSSLCertificate intentionally bypasses validation' {
+
+        # SECURITY contract test: Get-RemoteSSLCertificate documents that it
+        # accepts any server certificate so operators can inspect expired,
+        # self-signed, and otherwise invalid certs. expired.badssl.com serves
+        # a cert with NotAfter in the past; if a future change re-enables
+        # validation, AuthenticateAsClient will throw and this test will fail
+        # loudly. See the SECURITY note in Get-RemoteSSLCertificate's help.
+
+        It 'Retrieves an expired certificate without throwing' {
+            $expiredHost = 'expired.badssl.com'
+            $cert = Get-RemoteSSLCertificate -ComputerName $expiredHost -Port 443
+            $cert           | Should -BeOfType ([System.Security.Cryptography.X509Certificates.X509Certificate2])
+            $cert.NotAfter  | Should -BeLessThan (Get-Date)
+        }
+    }
 }

--- a/Tests/Integration/PS.SSL.Network.Integration.Tests.ps1
+++ b/Tests/Integration/PS.SSL.Network.Integration.Tests.ps1
@@ -1,0 +1,101 @@
+BeforeDiscovery {
+    # Probe a well-known TLS endpoint at discovery time so CI runners
+    # without outbound network access skip cleanly instead of failing.
+    # `badssl.com` is a public TLS test endpoint maintained for exactly
+    # this kind of probe; if it's reachable we have a high-quality target.
+    $script:NetworkTarget = 'badssl.com'
+    $script:NetworkPort   = 443
+    $script:NetworkReachable = $false
+    try {
+        $client = [System.Net.Sockets.TcpClient]::new()
+        $task   = $client.ConnectAsync($script:NetworkTarget, $script:NetworkPort)
+        if ($task.Wait([System.TimeSpan]::FromSeconds(3))) {
+            $script:NetworkReachable = $client.Connected
+        }
+        $client.Dispose()
+    }
+    catch {
+        $script:NetworkReachable = $false
+    }
+}
+
+BeforeAll {
+    $manifestPath = if ($env:BHPSModuleManifest) {
+        $env:BHPSModuleManifest
+    }
+    else {
+        Join-Path -Path $PSScriptRoot -ChildPath '..\..\PS.SSL.psd1' | Resolve-Path | Select-Object -ExpandProperty Path
+    }
+    Get-Module -Name 'PS.SSL' -All | Remove-Module -Force -ErrorAction SilentlyContinue
+    Import-Module -Name $manifestPath -Force
+
+    # Discovery-scope variables aren't visible to It bodies, so re-declare
+    # the network target here for runtime use.
+    $script:NetworkTarget = 'badssl.com'
+    $script:NetworkPort   = 443
+}
+
+Describe 'PS.SSL network integration (real TLS endpoint)' -Tag 'Integration', 'Network' -Skip:(-not $script:NetworkReachable) {
+
+    Context 'Test-SSLProtocol against badssl.com:443' {
+
+        BeforeAll {
+            # Run the probe once and reuse - each call opens 6+ sockets and
+            # performs a real TLS handshake per protocol enum value, which
+            # is expensive and we don't want to hammer the public endpoint.
+            $script:result = Test-SSLProtocol -ComputerName $script:NetworkTarget -Port $script:NetworkPort
+        }
+
+        It 'Returns a PSCustomObject' {
+            $script:result | Should -BeOfType ([pscustomobject])
+        }
+
+        It 'Echoes ComputerName and Port to the output object verbatim' {
+            $script:result.ComputerName | Should -Be $script:NetworkTarget
+            $script:result.Port         | Should -Be $script:NetworkPort
+        }
+
+        It 'Populates the negotiated KeyLength as a positive integer' {
+            $script:result.KeyLength | Should -BeGreaterThan 0
+        }
+
+        It 'Populates SignatureAlgorithm with a non-empty string' {
+            $script:result.SignatureAlgorithm | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Exposes the remote certificate as an X509Certificate2' {
+            $script:result.Certificate | Should -BeOfType ([System.Security.Cryptography.X509Certificates.X509Certificate2])
+        }
+
+        It 'Reports at least one modern TLS protocol (Tls12 or Tls13) as supported' {
+            $modernProtocols = @('Tls12', 'Tls13') | Where-Object {
+                $script:result.PSObject.Properties.Name -contains $_
+            }
+            $modernProtocols.Count | Should -BeGreaterThan 0
+
+            $supportedModern = $modernProtocols | Where-Object { $script:result.$_ -eq $true }
+            $supportedModern.Count | Should -BeGreaterThan 0
+        }
+
+        It 'Encodes each probed protocol as a boolean property' {
+            # Function iterates [SslProtocols] enum, skipping Default/None.
+            # Every property added by the probe loop must be $true or $false.
+            $protocolProps = $script:result.PSObject.Properties |
+                Where-Object { $_.Name -notin 'ComputerName', 'Port', 'KeyLength', 'KeyExchange',
+                                              'HashAlgorithm', 'SignatureAlgorithm', 'Certificate' }
+            $protocolProps.Count | Should -BeGreaterThan 0
+            foreach ($p in $protocolProps) {
+                $p.Value | Should -BeOfType ([bool])
+            }
+        }
+    }
+
+    Context 'Test-SSLProtocol accepts pipeline input' {
+
+        It 'Accepts -ComputerName from the pipeline' {
+            $result = $script:NetworkTarget | Test-SSLProtocol -Port $script:NetworkPort
+            $result              | Should -Not -BeNullOrEmpty
+            $result.ComputerName | Should -Be $script:NetworkTarget
+        }
+    }
+}

--- a/Tests/Unit/ConvertFrom-PKCS7.Tests.ps1
+++ b/Tests/Unit/ConvertFrom-PKCS7.Tests.ps1
@@ -1,0 +1,83 @@
+BeforeAll {
+    $manifestPath = if ($env:BHPSModuleManifest) {
+        $env:BHPSModuleManifest
+    }
+    else {
+        Join-Path -Path $PSScriptRoot -ChildPath '..\..\PS.SSL.psd1' | Resolve-Path | Select-Object -ExpandProperty Path
+    }
+    Get-Module -Name 'PS.SSL' -All | Remove-Module -Force -ErrorAction SilentlyContinue
+    Import-Module -Name $manifestPath -Force
+}
+
+Describe 'ConvertFrom-PKCS7' {
+
+    BeforeEach {
+        # Mock the openssl boundary and the output-directory helper so the
+        # unit test never touches openssl and never validates paths against
+        # the real filesystem.
+        Mock -ModuleName PS.SSL Invoke-OpenSsl           { }
+        Mock -ModuleName PS.SSL Initialize-OutputDirectory { }
+    }
+
+    Context 'Parameter validation' {
+
+        It 'Rejects a path that does not exist' {
+            $missing = Join-Path $TestDrive 'does-not-exist.cer'
+            { ConvertFrom-PKCS7 -Path $missing -OutputDirectory $TestDrive } | Should -Throw
+        }
+
+        It 'Rejects an unsupported input extension' {
+            $bad = Join-Path $TestDrive 'cert.pfx'
+            Set-Content -Path $bad -Value 'placeholder'
+            { ConvertFrom-PKCS7 -Path $bad -OutputDirectory $TestDrive } | Should -Throw
+        }
+
+        It 'Accepts .crt, .cer, and .pem extensions' {
+            foreach ($ext in '.crt', '.cer', '.pem') {
+                $path = Join-Path $TestDrive ('cert{0}' -f $ext)
+                Set-Content -Path $path -Value 'placeholder'
+                { ConvertFrom-PKCS7 -Path $path -OutputDirectory $TestDrive } | Should -Not -Throw
+            }
+        }
+    }
+
+    Context 'OpenSSL invocation' {
+
+        BeforeEach {
+            $script:inputPath = Join-Path $TestDrive 'mycert.cer'
+            Set-Content -Path $script:inputPath -Value 'placeholder'
+        }
+
+        It 'Calls openssl pkcs7 with -print_certs' {
+            ConvertFrom-PKCS7 -Path $script:inputPath -OutputDirectory $TestDrive
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Invoke-OpenSsl' -Times 1 -Exactly -ParameterFilter {
+                ($ArgumentList -contains 'pkcs7')        -and
+                ($ArgumentList -contains '-print_certs') -and
+                ($ArgumentList -contains '-in')          -and
+                ($ArgumentList -contains '-out')
+            }
+        }
+
+        It 'Passes the input path via -in' {
+            ConvertFrom-PKCS7 -Path $script:inputPath -OutputDirectory $TestDrive
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Invoke-OpenSsl' -Times 1 -Exactly -ParameterFilter {
+                $inIndex = [System.Array]::IndexOf($ArgumentList, '-in')
+                $inIndex -ge 0 -and $ArgumentList[$inIndex + 1] -eq $script:inputPath
+            }
+        }
+
+        It 'Writes the output as <LeafBase>.crt inside the output directory' {
+            ConvertFrom-PKCS7 -Path $script:inputPath -OutputDirectory $TestDrive
+            $expected = Join-Path -Path $TestDrive -ChildPath 'mycert.crt'
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Invoke-OpenSsl' -Times 1 -Exactly -ParameterFilter {
+                $outIndex = [System.Array]::IndexOf($ArgumentList, '-out')
+                $outIndex -ge 0 -and $ArgumentList[$outIndex + 1] -eq $expected
+            }
+        }
+
+        It 'Ensures the output directory is initialized before invoking openssl' {
+            ConvertFrom-PKCS7 -Path $script:inputPath -OutputDirectory $TestDrive
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Initialize-OutputDirectory' -Times 1 -Exactly
+        }
+    }
+}

--- a/Tests/Unit/ConvertTo-PEM.Tests.ps1
+++ b/Tests/Unit/ConvertTo-PEM.Tests.ps1
@@ -1,0 +1,117 @@
+BeforeAll {
+    $manifestPath = if ($env:BHPSModuleManifest) {
+        $env:BHPSModuleManifest
+    }
+    else {
+        Join-Path -Path $PSScriptRoot -ChildPath '..\..\PS.SSL.psd1' | Resolve-Path | Select-Object -ExpandProperty Path
+    }
+    Get-Module -Name 'PS.SSL' -All | Remove-Module -Force -ErrorAction SilentlyContinue
+    Import-Module -Name $manifestPath -Force
+}
+
+Describe 'ConvertTo-PEM' {
+
+    BeforeEach {
+        # Mock all external boundaries: openssl, the PFX password sanity
+        # check, and the output-directory helper. Get-PfxCertificate is a
+        # built-in cmdlet but it is called from inside the module, so it
+        # must be mocked with -ModuleName.
+        Mock -ModuleName PS.SSL Invoke-OpenSsl             { }
+        Mock -ModuleName PS.SSL Initialize-OutputDirectory { }
+        Mock -ModuleName PS.SSL Get-PfxCertificate         { }
+
+        $script:pfxPath = Join-Path $TestDrive 'bundle.pfx'
+        Set-Content -Path $script:pfxPath -Value 'placeholder'
+        $script:password = ConvertTo-SecureString -String 'NotARealPassword!1' -AsPlainText -Force
+    }
+
+    Context 'Parameter validation' {
+
+        It 'Rejects a path that does not exist' {
+            $missing = Join-Path $TestDrive 'missing.pfx'
+            { ConvertTo-PEM -Path $missing -OutputDirectory $TestDrive -Password $script:password } | Should -Throw
+        }
+
+        It 'Rejects an unsupported input extension' {
+            $bad = Join-Path $TestDrive 'bundle.pem'
+            Set-Content -Path $bad -Value 'placeholder'
+            { ConvertTo-PEM -Path $bad -OutputDirectory $TestDrive -Password $script:password } | Should -Throw
+        }
+
+        It 'Accepts both .pfx and .p12 extensions' {
+            foreach ($ext in '.pfx', '.p12') {
+                $path = Join-Path $TestDrive ('bundle{0}' -f $ext)
+                Set-Content -Path $path -Value 'placeholder'
+                { ConvertTo-PEM -Path $path -OutputDirectory $TestDrive -Password $script:password } | Should -Not -Throw
+            }
+        }
+
+        It 'Accepts the legacy -PFX alias' {
+            { ConvertTo-PEM -PFX $script:pfxPath -OutputDirectory $TestDrive -Password $script:password } | Should -Not -Throw
+        }
+
+        It 'Requires a non-empty SecureString password' {
+            { ConvertTo-PEM -Path $script:pfxPath -OutputDirectory $TestDrive -Password $null } | Should -Throw
+        }
+    }
+
+    Context 'OpenSSL invocation' {
+
+        It 'Calls openssl pkcs12 with -nodes' {
+            ConvertTo-PEM -Path $script:pfxPath -OutputDirectory $TestDrive -Password $script:password
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Invoke-OpenSsl' -Times 1 -Exactly -ParameterFilter {
+                ($ArgumentList -contains 'pkcs12') -and
+                ($ArgumentList -contains '-nodes') -and
+                ($ArgumentList -contains '-in')    -and
+                ($ArgumentList -contains '-out')
+            }
+        }
+
+        It 'Writes the output as <LeafBase>.pem inside the output directory' {
+            ConvertTo-PEM -Path $script:pfxPath -OutputDirectory $TestDrive -Password $script:password
+            $expected = Join-Path -Path $TestDrive -ChildPath 'bundle.pem'
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Invoke-OpenSsl' -Times 1 -Exactly -ParameterFilter {
+                $outIndex = [System.Array]::IndexOf($ArgumentList, '-out')
+                $outIndex -ge 0 -and $ArgumentList[$outIndex + 1] -eq $expected
+            }
+        }
+
+        It 'Validates the password via Get-PfxCertificate before invoking openssl' {
+            ConvertTo-PEM -Path $script:pfxPath -OutputDirectory $TestDrive -Password $script:password
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Get-PfxCertificate' -Times 1 -Exactly
+        }
+    }
+
+    Context 'Password handoff (security-critical)' {
+
+        It 'Routes the password via -passin env:PSSL_PASSIN, never on argv' {
+            ConvertTo-PEM -Path $script:pfxPath -OutputDirectory $TestDrive -Password $script:password
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Invoke-OpenSsl' -Times 1 -Exactly -ParameterFilter {
+                $passinIndex = [System.Array]::IndexOf($ArgumentList, '-passin')
+                $passinIndex -ge 0 -and $ArgumentList[$passinIndex + 1] -eq 'env:PSSL_PASSIN'
+            }
+        }
+
+        It 'Never places the plain-text password on argv' {
+            ConvertTo-PEM -Path $script:pfxPath -OutputDirectory $TestDrive -Password $script:password
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Invoke-OpenSsl' -Times 1 -Exactly -ParameterFilter {
+                ($ArgumentList -join ' ') -notmatch 'NotARealPassword'
+            }
+        }
+
+        It 'Hands the SecureString to Invoke-OpenSsl via -EnvironmentVariable PSSL_PASSIN' {
+            ConvertTo-PEM -Path $script:pfxPath -OutputDirectory $TestDrive -Password $script:password
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Invoke-OpenSsl' -Times 1 -Exactly -ParameterFilter {
+                $EnvironmentVariable -is [hashtable]              -and
+                $EnvironmentVariable.ContainsKey('PSSL_PASSIN')   -and
+                $EnvironmentVariable['PSSL_PASSIN'] -is [System.Security.SecureString]
+            }
+        }
+
+        It 'Does not leak PSSL_PASSIN into the parent session environment' {
+            $env:PSSL_PASSIN | Should -BeNullOrEmpty
+            ConvertTo-PEM -Path $script:pfxPath -OutputDirectory $TestDrive -Password $script:password
+            $env:PSSL_PASSIN | Should -BeNullOrEmpty
+        }
+    }
+}

--- a/Tests/Unit/Export-Base64Certificate.Tests.ps1
+++ b/Tests/Unit/Export-Base64Certificate.Tests.ps1
@@ -5,6 +5,10 @@ BeforeAll {
     else {
         Join-Path -Path $PSScriptRoot -ChildPath '..\..\PS.SSL.psd1' | Resolve-Path | Select-Object -ExpandProperty Path
     }
+    # See New-CertificateSigningRequest.Tests.ps1 for rationale: `-Force` does
+    # not displace a module loaded from a different absolute path, so remove
+    # all existing PS.SSL copies before importing to keep the session clean.
+    Get-Module -Name 'PS.SSL' -All | Remove-Module -Force -ErrorAction SilentlyContinue
     Import-Module -Name $manifestPath -Force
 }
 

--- a/Tests/Unit/Export-Base64Certificate.Tests.ps1
+++ b/Tests/Unit/Export-Base64Certificate.Tests.ps1
@@ -1,0 +1,70 @@
+BeforeAll {
+    $manifestPath = if ($env:BHPSModuleManifest) {
+        $env:BHPSModuleManifest
+    }
+    else {
+        Join-Path -Path $PSScriptRoot -ChildPath '..\..\PS.SSL.psd1' | Resolve-Path | Select-Object -ExpandProperty Path
+    }
+    Import-Module -Name $manifestPath -Force
+}
+
+Describe 'Export-Base64Certificate' {
+
+    Context 'Parameter validation' {
+        It 'Rejects an empty byte array' {
+            { Export-Base64Certificate -ByteArray @() -Path (Join-Path $TestDrive 'empty.crt') } | Should -Throw
+        }
+
+        It 'Rejects a path that does not end in .crt' {
+            { Export-Base64Certificate -ByteArray ([byte[]](1, 2, 3)) -Path (Join-Path $TestDrive 'wrong-ext.pem') } | Should -Throw
+        }
+
+        It 'Rejects a path whose parent directory does not exist' {
+            { Export-Base64Certificate -ByteArray ([byte[]](1, 2, 3)) -Path (Join-Path $TestDrive 'no\such\dir\out.crt') } | Should -Throw
+        }
+
+        It 'Rejects a path that already exists' {
+            $existing = Join-Path $TestDrive 'already-there.crt'
+            Set-Content -Path $existing -Value 'placeholder'
+            { Export-Base64Certificate -ByteArray ([byte[]](1, 2, 3)) -Path $existing } | Should -Throw
+        }
+    }
+
+    Context 'PEM output format' {
+
+        BeforeAll {
+            # 256 bytes -> 344 base64 chars -> six 64-char lines + one 56-char tail
+            $script:bytes   = [byte[]](0..255)
+            $script:outPath = Join-Path $TestDrive 'roundtrip.crt'
+            Export-Base64Certificate -ByteArray $script:bytes -Path $script:outPath
+            $script:lines   = Get-Content -Path $script:outPath
+        }
+
+        It 'Writes the PEM BEGIN CERTIFICATE header on the first line' {
+            $script:lines[0] | Should -BeExactly '-----BEGIN CERTIFICATE-----'
+        }
+
+        It 'Writes the PEM END CERTIFICATE footer on the last line' {
+            $script:lines[-1] | Should -BeExactly '-----END CERTIFICATE-----'
+        }
+
+        It 'Wraps every body line except the last at 64 characters (RFC 7468)' {
+            $body = $script:lines[1..($script:lines.Length - 2)]
+            $body.Length | Should -BeGreaterThan 0
+            foreach ($line in $body[0..($body.Length - 2)]) {
+                $line.Length | Should -Be 64
+            }
+        }
+
+        It 'Caps the last body line at 64 characters or fewer' {
+            $body = $script:lines[1..($script:lines.Length - 2)]
+            $body[-1].Length | Should -BeLessOrEqual 64
+        }
+
+        It 'Round-trips through base64 decoding back to the original bytes' {
+            $body    = ($script:lines[1..($script:lines.Length - 2)]) -join ''
+            $decoded = [System.Convert]::FromBase64String($body)
+            $decoded | Should -Be $script:bytes
+        }
+    }
+}

--- a/Tests/Unit/Export-CertificateData.Tests.ps1
+++ b/Tests/Unit/Export-CertificateData.Tests.ps1
@@ -1,0 +1,104 @@
+BeforeAll {
+    $manifestPath = if ($env:BHPSModuleManifest) {
+        $env:BHPSModuleManifest
+    }
+    else {
+        Join-Path -Path $PSScriptRoot -ChildPath '..\..\PS.SSL.psd1' | Resolve-Path | Select-Object -ExpandProperty Path
+    }
+    Get-Module -Name 'PS.SSL' -All | Remove-Module -Force -ErrorAction SilentlyContinue
+    Import-Module -Name $manifestPath -Force
+
+    # Synthetic PEM bundle: 1 private key + 3 certificates (leaf + 2 chain).
+    # The actual base64 content is filler - Export-CertificateData scans for
+    # the standard PEM begin/end markers and slices line ranges verbatim; it
+    # never decodes the base64 body.
+    $script:samplePem = @(
+        '-----BEGIN PRIVATE KEY-----'
+        'AAAAKEYLINE1'
+        'AAAAKEYLINE2'
+        '-----END PRIVATE KEY-----'
+        '-----BEGIN CERTIFICATE-----'
+        'BBBBLEAFLINE1'
+        'BBBBLEAFLINE2'
+        '-----END CERTIFICATE-----'
+        '-----BEGIN CERTIFICATE-----'
+        'CCCCCHAIN1LINE1'
+        '-----END CERTIFICATE-----'
+        '-----BEGIN CERTIFICATE-----'
+        'DDDDCHAIN2LINE1'
+        '-----END CERTIFICATE-----'
+    ) -join [System.Environment]::NewLine
+}
+
+Describe 'Export-CertificateData' {
+
+    Context 'Parameter validation' {
+
+        It 'Rejects a path that does not exist' {
+            $missing = Join-Path $TestDrive 'does-not-exist.pem'
+            { Export-CertificateData -Path $missing -Data Certificate -OutputDirectory $TestDrive } | Should -Throw
+        }
+
+        It 'Rejects a path that does not end in .pem' {
+            $wrongExt = Join-Path $TestDrive 'bundle.txt'
+            Set-Content -Path $wrongExt -Value $script:samplePem
+            { Export-CertificateData -Path $wrongExt -Data Certificate -OutputDirectory $TestDrive } | Should -Throw
+        }
+
+        It 'Rejects an unsupported -Data value via ValidateSet' {
+            $bundle = Join-Path $TestDrive 'bundle.pem'
+            Set-Content -Path $bundle -Value $script:samplePem
+            { Export-CertificateData -Path $bundle -Data NotARealValue -OutputDirectory $TestDrive } | Should -Throw
+        }
+    }
+
+    Context 'Certificate extraction' {
+
+        BeforeEach {
+            $script:bundle = Join-Path $TestDrive 'bundle.pem'
+            Set-Content -Path $script:bundle -Value $script:samplePem
+            $script:outDir = Join-Path $TestDrive ('out-{0}' -f ([guid]::NewGuid().Guid.Substring(0, 8)))
+            New-Item -Path $script:outDir -ItemType Directory -Force | Out-Null
+        }
+
+        It 'Writes certificate.pem containing only the first CERTIFICATE block' {
+            Export-CertificateData -Path $script:bundle -Data Certificate -OutputDirectory $script:outDir
+            $cert = Join-Path $script:outDir 'certificate.pem'
+            Test-Path -Path $cert | Should -BeTrue
+            $content = Get-Content -Path $cert
+            $content[0]  | Should -BeExactly '-----BEGIN CERTIFICATE-----'
+            $content[-1] | Should -BeExactly '-----END CERTIFICATE-----'
+            ($content -join "`n") | Should -Match 'BBBBLEAFLINE'
+            ($content -join "`n") | Should -Not -Match 'CCCCCHAIN1'
+            ($content -join "`n") | Should -Not -Match 'DDDDCHAIN2'
+        }
+
+        It 'Writes chain.pem containing the 2nd and 3rd CERTIFICATE blocks' {
+            Export-CertificateData -Path $script:bundle -Data Chain -OutputDirectory $script:outDir
+            $chain = Join-Path $script:outDir 'chain.pem'
+            Test-Path -Path $chain | Should -BeTrue
+            $joined = (Get-Content -Path $chain) -join "`n"
+            $joined | Should -Match 'CCCCCHAIN1'
+            $joined | Should -Match 'DDDDCHAIN2'
+            $joined | Should -Not -Match 'BBBBLEAFLINE'
+        }
+
+        It 'Writes PRIVATE.key containing only the PRIVATE KEY block' {
+            Export-CertificateData -Path $script:bundle -Data PrivateKey -OutputDirectory $script:outDir
+            $key = Join-Path $script:outDir 'PRIVATE.key'
+            Test-Path -Path $key | Should -BeTrue
+            $content = Get-Content -Path $key
+            $content[0]  | Should -BeExactly '-----BEGIN PRIVATE KEY-----'
+            $content[-1] | Should -BeExactly '-----END PRIVATE KEY-----'
+            ($content -join "`n") | Should -Match 'AAAAKEYLINE'
+            ($content -join "`n") | Should -Not -Match 'CERTIFICATE'
+        }
+
+        It 'Creates the output directory if it does not yet exist' {
+            $newDir = Join-Path $TestDrive ('fresh-{0}' -f ([guid]::NewGuid().Guid.Substring(0, 8)))
+            Export-CertificateData -Path $script:bundle -Data Certificate -OutputDirectory $newDir
+            Test-Path -Path $newDir -PathType Container | Should -BeTrue
+            Test-Path -Path (Join-Path $newDir 'certificate.pem') | Should -BeTrue
+        }
+    }
+}

--- a/Tests/Unit/Export-PFX.Tests.ps1
+++ b/Tests/Unit/Export-PFX.Tests.ps1
@@ -1,0 +1,204 @@
+BeforeAll {
+    $manifestPath = if ($env:BHPSModuleManifest) {
+        $env:BHPSModuleManifest
+    }
+    else {
+        Join-Path -Path $PSScriptRoot -ChildPath '..\..\PS.SSL.psd1' | Resolve-Path | Select-Object -ExpandProperty Path
+    }
+    Get-Module -Name 'PS.SSL' -All | Remove-Module -Force -ErrorAction SilentlyContinue
+    Import-Module -Name $manifestPath -Force
+}
+
+Describe 'Export-PFX' {
+
+    BeforeEach {
+        # Mock the openssl and output-directory boundaries; the function
+        # itself still uses Get-Content/Set-Content for chain assembly so
+        # we let those touch $TestDrive.
+        Mock -ModuleName PS.SSL Invoke-OpenSsl             { }
+        Mock -ModuleName PS.SSL Initialize-OutputDirectory { }
+
+        # Real placeholder files - the function only inspects extensions
+        # and reads contents for the chain merge; it never parses them.
+        $script:keyPath  = Join-Path $TestDrive 'mydomain.com.key'
+        $script:csrPath  = Join-Path $TestDrive 'mydomain.com.crt'
+        $script:rootPath = Join-Path $TestDrive 'root.crt'
+        $script:intPath  = Join-Path $TestDrive 'intermediate.crt'
+        Set-Content -Path $script:keyPath  -Value 'KEY'
+        Set-Content -Path $script:csrPath  -Value 'CERT'
+        Set-Content -Path $script:rootPath -Value 'ROOT'
+        Set-Content -Path $script:intPath  -Value 'INTERMEDIATE'
+
+        $script:password = ConvertTo-SecureString -String 'NotARealPassword!1' -AsPlainText -Force
+    }
+
+    Context 'Parameter validation' {
+
+        It 'Rejects a missing private key path' {
+            $params = @{
+                Password      = $script:password
+                KeyPath       = Join-Path $TestDrive 'missing.key'
+                SignedCSRPath = $script:csrPath
+                OutputDirectory = $TestDrive
+            }
+            { Export-PFX @params } | Should -Throw
+        }
+
+        It 'Rejects an unsupported private key extension' {
+            $bad = Join-Path $TestDrive 'mydomain.com.txt'
+            Set-Content -Path $bad -Value 'KEY'
+            $params = @{
+                Password = $script:password; KeyPath = $bad
+                SignedCSRPath = $script:csrPath; OutputDirectory = $TestDrive
+            }
+            { Export-PFX @params } | Should -Throw
+        }
+
+        It 'Declares -RootCAPath as mandatory in the __fullchain parameter set' {
+            # When -IntermediateCAPath is supplied PowerShell binds the
+            # __fullchain set, which makes -RootCAPath mandatory. Verify the
+            # contract via the parameter metadata rather than by invoking
+            # the cmdlet (an unsupplied mandatory parameter prompts the host
+            # interactively, which would hang an automated test).
+            $cmd  = Get-Command -Name 'Export-PFX'
+            $root = $cmd.Parameters['RootCAPath']
+            $full = $root.ParameterSets['__fullchain']
+            $full         | Should -Not -BeNullOrEmpty
+            $full.IsMandatory | Should -BeTrue
+        }
+
+        It 'Accepts the legacy -Key/-SignedCSR/-RootCA aliases' {
+            $params = @{
+                Password = $script:password
+                Key = $script:keyPath; SignedCSR = $script:csrPath; RootCA = $script:rootPath
+                OutputDirectory = $TestDrive
+            }
+            { Export-PFX @params } | Should -Not -Throw
+        }
+    }
+
+    Context 'OpenSSL invocation' {
+
+        It 'Calls openssl pkcs12 -export with -inkey, -in, and -out' {
+            Export-PFX -Password $script:password -KeyPath $script:keyPath -SignedCSRPath $script:csrPath -OutputDirectory $TestDrive | Out-Null
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Invoke-OpenSsl' -Times 1 -Exactly -ParameterFilter {
+                ($ArgumentList -contains 'pkcs12') -and
+                ($ArgumentList -contains '-export') -and
+                ($ArgumentList -contains '-inkey') -and
+                ($ArgumentList -contains '-in') -and
+                ($ArgumentList -contains '-out')
+            }
+        }
+
+        It 'Writes the output PFX named after the signed CSR leaf-base, inside the output directory' {
+            $result = Export-PFX -Password $script:password -KeyPath $script:keyPath -SignedCSRPath $script:csrPath -OutputDirectory $TestDrive
+            $expected = Join-Path -Path $TestDrive -ChildPath 'mydomain.com.pfx'
+            $result | Should -Be $expected
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Invoke-OpenSsl' -Times 1 -Exactly -ParameterFilter {
+                $outIndex = [System.Array]::IndexOf($ArgumentList, '-out')
+                $outIndex -ge 0 -and $ArgumentList[$outIndex + 1] -eq $expected
+            }
+        }
+
+        It 'Returns the PFX path on the output stream' {
+            $result = Export-PFX -Password $script:password -KeyPath $script:keyPath -SignedCSRPath $script:csrPath -OutputDirectory $TestDrive
+            $result | Should -BeOfType ([System.String])
+            $result | Should -Match 'mydomain\.com\.pfx$'
+        }
+    }
+
+    Context 'Certificate chain assembly' {
+
+        It '__nochain: omits -certfile when no CA paths are supplied' {
+            Export-PFX -Password $script:password -KeyPath $script:keyPath -SignedCSRPath $script:csrPath -OutputDirectory $TestDrive | Out-Null
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Invoke-OpenSsl' -Times 1 -Exactly -ParameterFilter {
+                $ArgumentList -notcontains '-certfile'
+            }
+        }
+
+        It '__rootonly: passes -certfile <RootCAPath> directly (no merge file)' {
+            Export-PFX -Password $script:password -KeyPath $script:keyPath -SignedCSRPath $script:csrPath -RootCAPath $script:rootPath -OutputDirectory $TestDrive | Out-Null
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Invoke-OpenSsl' -Times 1 -Exactly -ParameterFilter {
+                $certfileIndex = [System.Array]::IndexOf($ArgumentList, '-certfile')
+                $certfileIndex -ge 0 -and $ArgumentList[$certfileIndex + 1] -eq $script:rootPath
+            }
+        }
+
+        It '__fullchain: builds CAChain.crt with intermediate first, then root' {
+            $params = @{
+                Password = $script:password; KeyPath = $script:keyPath
+                SignedCSRPath = $script:csrPath
+                IntermediateCAPath = $script:intPath; RootCAPath = $script:rootPath
+                OutputDirectory = $TestDrive
+            }
+            Export-PFX @params | Out-Null
+
+            $chainPath = Join-Path $TestDrive 'CAChain.crt'
+            Test-Path $chainPath | Should -BeTrue
+            $contents = Get-Content -Path $chainPath -Raw
+            $contents | Should -Match 'INTERMEDIATE'
+            $contents | Should -Match 'ROOT'
+            ($contents.IndexOf('INTERMEDIATE')) | Should -BeLessThan ($contents.IndexOf('ROOT'))
+
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Invoke-OpenSsl' -Times 1 -Exactly -ParameterFilter {
+                $certfileIndex = [System.Array]::IndexOf($ArgumentList, '-certfile')
+                $certfileIndex -ge 0 -and $ArgumentList[$certfileIndex + 1] -eq $chainPath
+            }
+        }
+    }
+
+    Context '-WindowsCompatible' {
+
+        It 'Adds -certpbe, -keypbe PBE-SHA1-3DES, and -nomac' {
+            Export-PFX -Password $script:password -KeyPath $script:keyPath -SignedCSRPath $script:csrPath -OutputDirectory $TestDrive -WindowsCompatible | Out-Null
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Invoke-OpenSsl' -Times 1 -Exactly -ParameterFilter {
+                ($ArgumentList -contains '-certpbe')       -and
+                ($ArgumentList -contains '-keypbe')        -and
+                ($ArgumentList -contains 'PBE-SHA1-3DES')  -and
+                ($ArgumentList -contains '-nomac')
+            }
+        }
+
+        It 'Omits the legacy PBE switches when -WindowsCompatible is not set' {
+            Export-PFX -Password $script:password -KeyPath $script:keyPath -SignedCSRPath $script:csrPath -OutputDirectory $TestDrive | Out-Null
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Invoke-OpenSsl' -Times 1 -Exactly -ParameterFilter {
+                ($ArgumentList -notcontains '-certpbe') -and
+                ($ArgumentList -notcontains '-keypbe')  -and
+                ($ArgumentList -notcontains '-nomac')
+            }
+        }
+    }
+
+    Context 'Password handoff (security-critical)' {
+
+        It 'Routes the password via -passout env:PSSL_PASSOUT, never on argv' {
+            Export-PFX -Password $script:password -KeyPath $script:keyPath -SignedCSRPath $script:csrPath -OutputDirectory $TestDrive | Out-Null
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Invoke-OpenSsl' -Times 1 -Exactly -ParameterFilter {
+                $passoutIndex = [System.Array]::IndexOf($ArgumentList, '-passout')
+                $passoutIndex -ge 0 -and $ArgumentList[$passoutIndex + 1] -eq 'env:PSSL_PASSOUT'
+            }
+        }
+
+        It 'Never places the plain-text password on argv' {
+            Export-PFX -Password $script:password -KeyPath $script:keyPath -SignedCSRPath $script:csrPath -OutputDirectory $TestDrive | Out-Null
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Invoke-OpenSsl' -Times 1 -Exactly -ParameterFilter {
+                ($ArgumentList -join ' ') -notmatch 'NotARealPassword'
+            }
+        }
+
+        It 'Hands the SecureString to Invoke-OpenSsl via -EnvironmentVariable PSSL_PASSOUT' {
+            Export-PFX -Password $script:password -KeyPath $script:keyPath -SignedCSRPath $script:csrPath -OutputDirectory $TestDrive | Out-Null
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Invoke-OpenSsl' -Times 1 -Exactly -ParameterFilter {
+                $EnvironmentVariable -is [hashtable]              -and
+                $EnvironmentVariable.ContainsKey('PSSL_PASSOUT')  -and
+                $EnvironmentVariable['PSSL_PASSOUT'] -is [System.Security.SecureString]
+            }
+        }
+
+        It 'Does not leak PSSL_PASSOUT into the parent session environment' {
+            $env:PSSL_PASSOUT | Should -BeNullOrEmpty
+            Export-PFX -Password $script:password -KeyPath $script:keyPath -SignedCSRPath $script:csrPath -OutputDirectory $TestDrive | Out-Null
+            $env:PSSL_PASSOUT | Should -BeNullOrEmpty
+        }
+    }
+}

--- a/Tests/Unit/Get-CSRData.Tests.ps1
+++ b/Tests/Unit/Get-CSRData.Tests.ps1
@@ -1,0 +1,158 @@
+BeforeAll {
+    $manifestPath = if ($env:BHPSModuleManifest) {
+        $env:BHPSModuleManifest
+    }
+    else {
+        Join-Path -Path $PSScriptRoot -ChildPath '..\..\PS.SSL.psd1' | Resolve-Path | Select-Object -ExpandProperty Path
+    }
+    Get-Module -Name 'PS.SSL' -All | Remove-Module -Force -ErrorAction SilentlyContinue
+    Import-Module -Name $manifestPath -Force
+
+    # Representative openssl `req -text -noout -verify` output for a 4096-bit
+    # RSA CSR with two SANs. The trailing "Certificate request self-signature
+    # verify OK" line is what the function uses to set the Verified property.
+    $script:opensslStdOut = @'
+Certificate request self-signature verify OK
+Certificate Request:
+    Data:
+        Version: 1 (0x0)
+        Subject: C = US, ST = California, L = Redlands, O = Esri, OU = IT, CN = test.example.com, emailAddress = admin@example.com
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (4096 bit)
+                Modulus:
+                    00:aa:bb:cc:dd
+                Exponent: 65537 (0x10001)
+        Attributes:
+        Requested Extensions:
+            X509v3 Key Usage:
+                Key Encipherment, Data Encipherment
+            X509v3 Extended Key Usage:
+                TLS Web Server Authentication
+            X509v3 Subject Alternative Name:
+                DNS:a.example.com, DNS:b.example.com
+    Signature Algorithm: sha256WithRSAEncryption
+    Signature Value:
+        00:11:22:33:44:55
+'@
+
+    $script:opensslStdOutFailed = $script:opensslStdOut -replace 'self-signature verify OK', 'Signature did not match the certificate request'
+}
+
+Describe 'Get-CSRData' {
+
+    Context 'Parameter validation' {
+
+        It 'Rejects a path that does not exist' {
+            $missing = Join-Path $TestDrive 'does-not-exist.csr'
+            { Get-CSRData -Path $missing } | Should -Throw
+        }
+
+        It 'Rejects a path with the wrong extension' {
+            $bad = Join-Path $TestDrive 'request.txt'
+            Set-Content -Path $bad -Value 'placeholder'
+            { Get-CSRData -Path $bad } | Should -Throw
+        }
+
+        It 'Accepts the legacy -CSR alias' {
+            $csrPath = Join-Path $TestDrive 'alias.csr'
+            Set-Content -Path $csrPath -Value 'placeholder'
+            Mock -ModuleName PS.SSL Invoke-OpenSsl {
+                [PSCustomObject] @{ ExitCode = 0; StdOut = $script:opensslStdOut; StdErr = '' }
+            }
+            { Get-CSRData -CSR $csrPath } | Should -Not -Throw
+        }
+    }
+
+    Context 'OpenSSL invocation' {
+
+        BeforeEach {
+            $script:csrPath = Join-Path $TestDrive 'sample.csr'
+            Set-Content -Path $script:csrPath -Value 'placeholder'
+            Mock -ModuleName PS.SSL Invoke-OpenSsl {
+                [PSCustomObject] @{ ExitCode = 0; StdOut = $script:opensslStdOut; StdErr = '' }
+            }
+        }
+
+        It 'Calls openssl req with -text -noout -verify' {
+            Get-CSRData -Path $script:csrPath | Out-Null
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Invoke-OpenSsl' -Times 1 -Exactly -ParameterFilter {
+                ($ArgumentList -contains 'req')     -and
+                ($ArgumentList -contains '-text')   -and
+                ($ArgumentList -contains '-noout')  -and
+                ($ArgumentList -contains '-verify') -and
+                ($ArgumentList -contains '-in')
+            }
+        }
+
+        It 'Uses -IgnoreExitCode so a failed verification is non-terminating' {
+            Get-CSRData -Path $script:csrPath | Out-Null
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Invoke-OpenSsl' -Times 1 -Exactly -ParameterFilter {
+                $IgnoreExitCode -eq $true
+            }
+        }
+    }
+
+    Context 'Parsed output shape' {
+
+        BeforeEach {
+            $script:csrPath = Join-Path $TestDrive 'sample.csr'
+            Set-Content -Path $script:csrPath -Value 'placeholder'
+            Mock -ModuleName PS.SSL Invoke-OpenSsl {
+                [PSCustomObject] @{ ExitCode = 0; StdOut = $script:opensslStdOut; StdErr = '' }
+            }
+            $script:result = Get-CSRData -Path $script:csrPath
+        }
+
+        It 'Returns a PSCustomObject with the full property contract' {
+            $script:result | Should -BeOfType ([pscustomobject])
+            foreach ($prop in 'Path', 'Subject', 'PublicKeyAlgorithm', 'PublicKeyBits',
+                              'SignatureAlgorithm', 'SubjectAlternativeName', 'Verified', 'Raw') {
+                $script:result.PSObject.Properties.Name | Should -Contain $prop
+            }
+        }
+
+        It 'Echoes the input path verbatim' {
+            $script:result.Path | Should -Be $script:csrPath
+        }
+
+        It 'Parses the Subject DN' {
+            $script:result.Subject | Should -Match 'CN = test\.example\.com'
+        }
+
+        It 'Parses the public key algorithm and bit length' {
+            $script:result.PublicKeyAlgorithm | Should -Be 'rsaEncryption'
+            $script:result.PublicKeyBits      | Should -Be 4096
+        }
+
+        It 'Parses the signature algorithm (last occurrence wins)' {
+            $script:result.SignatureAlgorithm | Should -Be 'sha256WithRSAEncryption'
+        }
+
+        It 'Parses SANs as a flat string array of DNS names' {
+            $script:result.SubjectAlternativeName | Should -Be @('a.example.com', 'b.example.com')
+        }
+
+        It 'Sets Verified=$true when openssl reports verification OK' {
+            $script:result.Verified | Should -BeTrue
+        }
+
+        It 'Preserves the full openssl output on the Raw property' {
+            $script:result.Raw | Should -Match 'Certificate Request:'
+            $script:result.Raw | Should -Match 'Subject Public Key Info:'
+        }
+    }
+
+    Context 'Failed verification' {
+
+        It 'Sets Verified=$false when openssl reports a signature mismatch' {
+            $csrPath = Join-Path $TestDrive 'bad.csr'
+            Set-Content -Path $csrPath -Value 'placeholder'
+            Mock -ModuleName PS.SSL Invoke-OpenSsl {
+                [PSCustomObject] @{ ExitCode = 1; StdOut = $script:opensslStdOutFailed; StdErr = '' }
+            }
+            $result = Get-CSRData -Path $csrPath
+            $result.Verified | Should -BeFalse
+        }
+    }
+}

--- a/Tests/Unit/Get-CSRData.Tests.ps1
+++ b/Tests/Unit/Get-CSRData.Tests.ps1
@@ -11,30 +11,32 @@ BeforeAll {
     # Representative openssl `req -text -noout -verify` output for a 4096-bit
     # RSA CSR with two SANs. The trailing "Certificate request self-signature
     # verify OK" line is what the function uses to set the Verified property.
-    $script:opensslStdOut = @'
-Certificate request self-signature verify OK
-Certificate Request:
-    Data:
-        Version: 1 (0x0)
-        Subject: C = US, ST = California, L = Redlands, O = Esri, OU = IT, CN = test.example.com, emailAddress = admin@example.com
-        Subject Public Key Info:
-            Public Key Algorithm: rsaEncryption
-                Public-Key: (4096 bit)
-                Modulus:
-                    00:aa:bb:cc:dd
-                Exponent: 65537 (0x10001)
-        Attributes:
-        Requested Extensions:
-            X509v3 Key Usage:
-                Key Encipherment, Data Encipherment
-            X509v3 Extended Key Usage:
-                TLS Web Server Authentication
-            X509v3 Subject Alternative Name:
-                DNS:a.example.com, DNS:b.example.com
-    Signature Algorithm: sha256WithRSAEncryption
-    Signature Value:
-        00:11:22:33:44:55
-'@
+    # Built as an array and joined so indentation aligns with surrounding code;
+    # the function parses StdOut as a single multi-line string.
+    $script:opensslStdOut = @(
+        'Certificate request self-signature verify OK'
+        'Certificate Request:'
+        '    Data:'
+        '        Version: 1 (0x0)'
+        '        Subject: C = US, ST = California, L = Redlands, O = Esri, OU = IT, CN = test.example.com, emailAddress = admin@example.com'
+        '        Subject Public Key Info:'
+        '            Public Key Algorithm: rsaEncryption'
+        '                Public-Key: (4096 bit)'
+        '                Modulus:'
+        '                    00:aa:bb:cc:dd'
+        '                Exponent: 65537 (0x10001)'
+        '        Attributes:'
+        '        Requested Extensions:'
+        '            X509v3 Key Usage:'
+        '                Key Encipherment, Data Encipherment'
+        '            X509v3 Extended Key Usage:'
+        '                TLS Web Server Authentication'
+        '            X509v3 Subject Alternative Name:'
+        '                DNS:a.example.com, DNS:b.example.com'
+        '    Signature Algorithm: sha256WithRSAEncryption'
+        '    Signature Value:'
+        '        00:11:22:33:44:55'
+    ) -join [System.Environment]::NewLine
 
     $script:opensslStdOutFailed = $script:opensslStdOut -replace 'self-signature verify OK', 'Signature did not match the certificate request'
 }

--- a/Tests/Unit/Get-CSRTemplate.Tests.ps1
+++ b/Tests/Unit/Get-CSRTemplate.Tests.ps1
@@ -1,0 +1,88 @@
+BeforeAll {
+    $manifestPath = if ($env:BHPSModuleManifest) {
+        $env:BHPSModuleManifest
+    }
+    else {
+        Join-Path -Path $PSScriptRoot -ChildPath '..\..\PS.SSL.psd1' | Resolve-Path | Select-Object -ExpandProperty Path
+    }
+    # See New-CertificateSigningRequest.Tests.ps1 for rationale: `-Force` does
+    # not displace a module loaded from a different absolute path, so remove
+    # all existing PS.SSL copies before importing to keep the session clean.
+    Get-Module -Name 'PS.SSL' -All | Remove-Module -Force -ErrorAction SilentlyContinue
+    Import-Module -Name $manifestPath -Force
+}
+
+Describe 'Get-CSRTemplate' {
+
+    Context 'Output shape' {
+
+        BeforeAll {
+            $script:template = Get-CSRTemplate
+        }
+
+        It 'Returns a non-empty string array' {
+            $script:template | Should -Not -BeNullOrEmpty
+            $script:template.GetType().Name | Should -Be 'Object[]'
+            $script:template.Count | Should -BeGreaterThan 0
+        }
+
+        It 'Returns one element per template line (no embedded newlines)' {
+            foreach ($line in $script:template) {
+                $line | Should -BeOfType ([string])
+                $line | Should -Not -Match "`n"
+            }
+        }
+    }
+
+    Context 'Template content' {
+
+        BeforeAll {
+            $script:template = Get-CSRTemplate
+            $script:joined = $script:template -join "`n"
+        }
+
+        It 'Starts with the [req] section header' {
+            $script:template[0] | Should -BeExactly '[req]'
+        }
+
+        It 'Includes all required openssl req sections' {
+            $script:joined | Should -Match '\[req\]'
+            $script:joined | Should -Match '\[req_distinguished_name\]'
+            $script:joined | Should -Match '\[v3_req\]'
+            $script:joined | Should -Match '\[alt_names\]'
+        }
+
+        It 'Sets prompt to no for unattended generation' {
+            $script:joined | Should -Match 'prompt\s*=\s*no'
+        }
+
+        It 'Sets default key size to 4096 and digest to sha256' {
+            $script:joined | Should -Match 'default_bits\s*=\s*4096'
+            $script:joined | Should -Match 'default_md\s*=\s*sha256'
+        }
+
+        It 'Includes all expected #TOKEN# placeholders for Build-CsrConfig' {
+            foreach ($token in '#C#', '#ST#', '#L#', '#O#', '#OU#', '#E#', '#CN#') {
+                $script:joined | Should -Match ([regex]::Escape($token))
+            }
+        }
+
+        It 'Declares serverAuth extended key usage' {
+            $script:joined | Should -Match 'extendedKeyUsage\s*=\s*serverAuth'
+        }
+
+        It 'References alt_names section via subjectAltName' {
+            $script:joined | Should -Match 'subjectAltName\s*=\s*@alt_names'
+        }
+    }
+
+    Context 'Pipeline usability' {
+
+        It 'Pipes to Set-Content to produce a readable file' {
+            $outFile = Join-Path $TestDrive 'template.conf'
+            Get-CSRTemplate | Set-Content -Path $outFile
+            Test-Path -Path $outFile | Should -BeTrue
+            (Get-Content -Path $outFile)[0] | Should -BeExactly '[req]'
+        }
+    }
+}

--- a/Tests/Unit/Get-CertificateData.Tests.ps1
+++ b/Tests/Unit/Get-CertificateData.Tests.ps1
@@ -1,0 +1,123 @@
+BeforeAll {
+    $manifestPath = if ($env:BHPSModuleManifest) {
+        $env:BHPSModuleManifest
+    }
+    else {
+        Join-Path -Path $PSScriptRoot -ChildPath '..\..\PS.SSL.psd1' | Resolve-Path | Select-Object -ExpandProperty Path
+    }
+    Get-Module -Name 'PS.SSL' -All | Remove-Module -Force -ErrorAction SilentlyContinue
+    Import-Module -Name $manifestPath -Force
+
+    # A minimal valid DER blob that .NET X509Certificate2::new() will accept
+    # would still need to be a real cert. To avoid bundling a binary fixture,
+    # we generate a self-signed cert in-memory with .NET, export to DER, and
+    # have the mocked Invoke-OpenSsl write those bytes to the temp DER path.
+    $rsa = [System.Security.Cryptography.RSA]::Create(2048)
+    try {
+        $req = [System.Security.Cryptography.X509Certificates.CertificateRequest]::new(
+            'CN=PSSL Unit Test',
+            $rsa,
+            [System.Security.Cryptography.HashAlgorithmName]::SHA256,
+            [System.Security.Cryptography.RSASignaturePadding]::Pkcs1
+        )
+        $cert = $req.CreateSelfSigned([datetimeoffset]::UtcNow.AddDays(-1), [datetimeoffset]::UtcNow.AddDays(30))
+        $script:fixtureDer  = $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert)
+        $script:fixtureThumbprint = $cert.Thumbprint
+    }
+    finally {
+        $rsa.Dispose()
+    }
+}
+
+Describe 'Get-CertificateData' {
+
+    BeforeEach {
+        # Mock the module-private openssl boundary. Get-CertificateData
+        # writes its DER output via `openssl x509 -outform DER -out <path>`
+        # then reads that file back. The mock locates the `-out` argument
+        # and writes the in-memory fixture DER bytes to that path.
+        Mock -ModuleName PS.SSL Invoke-OpenSsl {
+            $outIndex = [System.Array]::IndexOf($ArgumentList, '-out')
+            if ($outIndex -ge 0 -and $outIndex + 1 -lt $ArgumentList.Length) {
+                $outPath = $ArgumentList[$outIndex + 1]
+                [System.IO.File]::WriteAllBytes($outPath, $script:fixtureDer)
+            }
+            [PSCustomObject] @{ ExitCode = 0; StdOut = ''; StdErr = '' }
+        }
+    }
+
+    Context 'Parameter validation' {
+
+        It 'Rejects a path that does not exist' {
+            $missing = Join-Path $TestDrive 'does-not-exist.pem'
+            { Get-CertificateData -Path $missing } | Should -Throw
+        }
+
+        It 'Rejects a path with an unsupported extension' {
+            $bad = Join-Path $TestDrive 'cert.txt'
+            Set-Content -Path $bad -Value 'placeholder'
+            { Get-CertificateData -Path $bad } | Should -Throw
+        }
+
+        It 'Accepts .pem, .crt, and .cer extensions' {
+            foreach ($ext in '.pem', '.crt', '.cer') {
+                $path = Join-Path $TestDrive ('cert{0}' -f $ext)
+                Set-Content -Path $path -Value 'placeholder'
+                { Get-CertificateData -Path $path } | Should -Not -Throw
+            }
+        }
+    }
+
+    Context 'OpenSSL invocation' {
+
+        BeforeEach {
+            $script:certPath = Join-Path $TestDrive 'cert.pem'
+            Set-Content -Path $script:certPath -Value 'placeholder'
+        }
+
+        It 'Invokes openssl x509 with -outform DER' {
+            Get-CertificateData -Path $script:certPath | Out-Null
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Invoke-OpenSsl' -Times 1 -Exactly -ParameterFilter {
+                ($ArgumentList -contains 'x509')    -and
+                ($ArgumentList -contains '-in')     -and
+                ($ArgumentList -contains '-outform')-and
+                ($ArgumentList -contains 'DER')     -and
+                ($ArgumentList -contains '-out')
+            }
+        }
+
+        It 'Passes the input file path to openssl via -in' {
+            Get-CertificateData -Path $script:certPath | Out-Null
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Invoke-OpenSsl' -Times 1 -Exactly -ParameterFilter {
+                $inIndex = [System.Array]::IndexOf($ArgumentList, '-in')
+                $inIndex -ge 0 -and $ArgumentList[$inIndex + 1] -eq $script:certPath
+            }
+        }
+    }
+
+    Context 'Return type' {
+
+        BeforeEach {
+            $script:certPath = Join-Path $TestDrive 'cert.pem'
+            Set-Content -Path $script:certPath -Value 'placeholder'
+        }
+
+        It 'Returns an X509Certificate2 instance' {
+            $result = Get-CertificateData -Path $script:certPath
+            $result | Should -BeOfType ([System.Security.Cryptography.X509Certificates.X509Certificate2])
+        }
+
+        It 'Returns the certificate constructed from openssl-normalized DER bytes' {
+            $result = Get-CertificateData -Path $script:certPath
+            $result.Thumbprint | Should -Be $script:fixtureThumbprint
+            $result.Subject    | Should -Match 'PSSL Unit Test'
+        }
+
+        It 'Cleans up the temporary DER file after constructing the certificate' {
+            $tempBefore = Get-ChildItem -Path ([System.IO.Path]::GetTempPath()) -Filter 'pssl-cert-*.der' -ErrorAction SilentlyContinue
+            Get-CertificateData -Path $script:certPath | Out-Null
+            $tempAfter = Get-ChildItem -Path ([System.IO.Path]::GetTempPath()) -Filter 'pssl-cert-*.der' -ErrorAction SilentlyContinue
+            $tempAfter.Count | Should -Be $tempBefore.Count
+        }
+    }
+}

--- a/Tests/Unit/New-CertificateSigningRequest.Tests.ps1
+++ b/Tests/Unit/New-CertificateSigningRequest.Tests.ps1
@@ -5,6 +5,12 @@ BeforeAll {
     else {
         Join-Path -Path $PSScriptRoot -ChildPath '..\..\PS.SSL.psd1' | Resolve-Path | Select-Object -ExpandProperty Path
     }
+    # Remove any existing PS.SSL copies first. `-Force` re-imports but does
+    # not displace a module already loaded from a different absolute path
+    # (e.g. the staged build output vs. the source tree), which would leave
+    # two PS.SSL modules in the session and break `Mock -ModuleName PS.SSL`
+    # with "Multiple script or manifest modules ... currently loaded".
+    Get-Module -Name 'PS.SSL' -All | Remove-Module -Force -ErrorAction SilentlyContinue
     Import-Module -Name $manifestPath -Force
 }
 

--- a/Tests/Unit/New-CertificateSigningRequest.Tests.ps1
+++ b/Tests/Unit/New-CertificateSigningRequest.Tests.ps1
@@ -1,0 +1,113 @@
+BeforeAll {
+    $manifestPath = if ($env:BHPSModuleManifest) {
+        $env:BHPSModuleManifest
+    }
+    else {
+        Join-Path -Path $PSScriptRoot -ChildPath '..\..\PS.SSL.psd1' | Resolve-Path | Select-Object -ExpandProperty Path
+    }
+    Import-Module -Name $manifestPath -Force
+}
+
+Describe 'New-CertificateSigningRequest' {
+
+    BeforeEach {
+        # Mock the module-private boundary so the unit test never touches
+        # openssl, never touches disk for the rendered .conf, and never
+        # validates the output directory against the filesystem.
+        Mock -ModuleName PS.SSL Invoke-OpenSsl          { }
+        Mock -ModuleName PS.SSL Initialize-OutputDirectory { }
+        Mock -ModuleName PS.SSL Build-CsrConfig         { }
+    }
+
+    Context '__input parameter set' {
+
+        It 'Invokes openssl with req/-new/-nodes/-sha256 and the default rsa:4096 key size' {
+            New-CertificateSigningRequest -CommonName 'test.example.com' -OutputDirectory $TestDrive -Confirm:$false
+
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Invoke-OpenSsl' -Times 1 -Exactly -ParameterFilter {
+                $joined = $ArgumentList -join ' '
+                ($ArgumentList -contains 'req')     -and
+                ($ArgumentList -contains '-new')    -and
+                ($ArgumentList -contains '-nodes')  -and
+                ($ArgumentList -contains '-sha256') -and
+                ($ArgumentList -contains '-newkey') -and
+                ($joined -match 'rsa:4096')         -and
+                ($joined -match 'test\.example\.com\.csr') -and
+                ($joined -match 'test\.example\.com_PRIVATE\.key')
+            }
+        }
+
+        It 'Delegates config rendering to Build-CsrConfig' {
+            New-CertificateSigningRequest -CommonName 'test.example.com' -OutputDirectory $TestDrive -Confirm:$false
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Build-CsrConfig' -Times 1 -Exactly
+        }
+
+        It 'Emits the requested KeySize verbatim to openssl' {
+            New-CertificateSigningRequest -CommonName 'test.example.com' -OutputDirectory $TestDrive -KeySize 2048 -Confirm:$false
+
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Invoke-OpenSsl' -Times 1 -Exactly -ParameterFilter {
+                ($ArgumentList -join ' ') -match 'rsa:2048'
+            }
+        }
+
+        It 'Rejects an unsupported KeySize via ValidateSet' {
+            { New-CertificateSigningRequest -CommonName 'test.example.com' -OutputDirectory $TestDrive -KeySize 1024 -Confirm:$false } |
+                Should -Throw
+        }
+
+        It 'Skips the openssl invocation when called with -WhatIf' {
+            New-CertificateSigningRequest -CommonName 'test.example.com' -OutputDirectory $TestDrive -WhatIf
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Invoke-OpenSsl' -Times 0 -Exactly
+        }
+
+        It 'Rejects a CommonName whose TLD is outside the allow-list' {
+            { New-CertificateSigningRequest -CommonName 'test.example.xyz' -OutputDirectory $TestDrive -Confirm:$false } |
+                Should -Throw
+        }
+    }
+
+    Context '__conf parameter set' {
+
+        It 'Derives the artifact basename from the CN= line in the supplied config' {
+            $confPath = Join-Path $TestDrive 'fromfile.conf'
+            Set-Content -Path $confPath -Value @(
+                '[req]'
+                'prompt = no'
+                'distinguished_name = dn'
+                '[dn]'
+                'CN = www.fromfile.com'
+            )
+
+            New-CertificateSigningRequest -ConfigFile $confPath -OutputDirectory $TestDrive -Confirm:$false
+
+            # __conf mode must NOT re-render the config via Build-CsrConfig;
+            # it uses the caller's file as-is.
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Build-CsrConfig' -Times 0 -Exactly
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Invoke-OpenSsl'  -Times 1 -Exactly -ParameterFilter {
+                ($ArgumentList -join ' ') -match 'www\.fromfile\.com\.csr'
+            }
+        }
+
+        It 'Replaces the wildcard "*" with "star" in derived artifact filenames' {
+            # __conf mode reads CN from the caller's file and bypasses the
+            # CommonName ValidatePattern, so this is the only path where the
+            # wildcard rewrite in New-CertificateSigningRequest is reachable.
+            $confPath = Join-Path $TestDrive 'wildcard.conf'
+            Set-Content -Path $confPath -Value @(
+                '[req]'
+                'prompt = no'
+                'distinguished_name = dn'
+                '[dn]'
+                'CN = *.example.com'
+            )
+
+            New-CertificateSigningRequest -ConfigFile $confPath -OutputDirectory $TestDrive -Confirm:$false
+
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Invoke-OpenSsl' -Times 1 -Exactly -ParameterFilter {
+                $joined = $ArgumentList -join ' '
+                ($joined -match 'star\.example\.com\.csr') -and
+                ($joined -notmatch '\*')
+            }
+        }
+    }
+}

--- a/Tests/Unit/New-SelfSignedCertificate.Tests.ps1
+++ b/Tests/Unit/New-SelfSignedCertificate.Tests.ps1
@@ -1,0 +1,140 @@
+BeforeAll {
+    $manifestPath = if ($env:BHPSModuleManifest) {
+        $env:BHPSModuleManifest
+    }
+    else {
+        Join-Path -Path $PSScriptRoot -ChildPath '..\..\PS.SSL.psd1' | Resolve-Path | Select-Object -ExpandProperty Path
+    }
+    Get-Module -Name 'PS.SSL' -All | Remove-Module -Force -ErrorAction SilentlyContinue
+    Import-Module -Name $manifestPath -Force
+}
+
+Describe 'New-SelfSignedCertificate' {
+
+    BeforeEach {
+        # Mock the module-private boundary so the unit test never touches
+        # openssl, never writes a .conf, and never validates paths against
+        # the real filesystem.
+        Mock -ModuleName PS.SSL Invoke-OpenSsl             { }
+        Mock -ModuleName PS.SSL Initialize-OutputDirectory { }
+        Mock -ModuleName PS.SSL Build-CsrConfig            { }
+    }
+
+    Context '__input parameter set' {
+
+        It 'Invokes openssl req -x509 with -new -nodes -sha256 and default rsa:4096' {
+            New-SelfSignedCertificate -CommonName 'test.example.com' -OutputDirectory $TestDrive -Confirm:$false
+
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Invoke-OpenSsl' -Times 1 -Exactly -ParameterFilter {
+                $joined = $ArgumentList -join ' '
+                ($ArgumentList -contains 'req')     -and
+                ($ArgumentList -contains '-x509')   -and
+                ($ArgumentList -contains '-new')    -and
+                ($ArgumentList -contains '-nodes')  -and
+                ($ArgumentList -contains '-sha256') -and
+                ($ArgumentList -contains '-newkey') -and
+                ($joined -match 'rsa:4096')         -and
+                ($joined -match 'test\.example\.com\.pem')         -and
+                ($joined -match 'test\.example\.com_PRIVATE\.key')
+            }
+        }
+
+        It 'Delegates config rendering to Build-CsrConfig' {
+            New-SelfSignedCertificate -CommonName 'test.example.com' -OutputDirectory $TestDrive -Confirm:$false
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Build-CsrConfig' -Times 1 -Exactly
+        }
+
+        It 'Emits the requested KeySize verbatim to openssl' {
+            New-SelfSignedCertificate -CommonName 'test.example.com' -OutputDirectory $TestDrive -KeySize 2048 -Confirm:$false
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Invoke-OpenSsl' -Times 1 -Exactly -ParameterFilter {
+                ($ArgumentList -join ' ') -match 'rsa:2048'
+            }
+        }
+
+        It 'Emits -days with the requested validity period' {
+            New-SelfSignedCertificate -CommonName 'test.example.com' -OutputDirectory $TestDrive -Days 730 -Confirm:$false
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Invoke-OpenSsl' -Times 1 -Exactly -ParameterFilter {
+                $daysIndex = [System.Array]::IndexOf($ArgumentList, '-days')
+                $daysIndex -ge 0 -and $ArgumentList[$daysIndex + 1] -eq '730'
+            }
+        }
+
+        It 'Defaults to 365 days when -Days is not supplied' {
+            New-SelfSignedCertificate -CommonName 'test.example.com' -OutputDirectory $TestDrive -Confirm:$false
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Invoke-OpenSsl' -Times 1 -Exactly -ParameterFilter {
+                $daysIndex = [System.Array]::IndexOf($ArgumentList, '-days')
+                $daysIndex -ge 0 -and $ArgumentList[$daysIndex + 1] -eq '365'
+            }
+        }
+
+        It 'Rejects an unsupported KeySize via ValidateSet' {
+            { New-SelfSignedCertificate -CommonName 'test.example.com' -OutputDirectory $TestDrive -KeySize 1024 -Confirm:$false } | Should -Throw
+        }
+
+        It 'Rejects an out-of-range -Days value' {
+            { New-SelfSignedCertificate -CommonName 'test.example.com' -OutputDirectory $TestDrive -Days 10 -Confirm:$false } | Should -Throw
+        }
+
+        It 'Rejects an invalid CommonName pattern' {
+            { New-SelfSignedCertificate -CommonName 'invalid host name!' -OutputDirectory $TestDrive -Confirm:$false } | Should -Throw
+        }
+
+    }
+
+    Context '__conf parameter set' {
+
+        It 'Sanitizes a wildcard CN from the config file to "star" in output file names' {
+            $confPath = Join-Path $TestDrive 'wildcard.conf'
+            Set-Content -Path $confPath -Value @('[req]', 'prompt = no', 'CN = *.example.com')
+
+            New-SelfSignedCertificate -ConfigFile $confPath -OutputDirectory $TestDrive -Confirm:$false
+
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Invoke-OpenSsl' -Times 1 -Exactly -ParameterFilter {
+                $joined = $ArgumentList -join ' '
+                ($joined -match 'star\.example\.com\.pem') -and
+                ($joined -match 'star\.example\.com_PRIVATE\.key') -and
+                ($joined -notmatch '\*')
+            }
+        }
+
+        It 'Uses the caller-supplied -ConfigFile and skips Build-CsrConfig' {
+            $confPath = Join-Path $TestDrive 'custom.conf'
+            Set-Content -Path $confPath -Value @('[req]', 'prompt = no', 'CN = conf.example.com')
+
+            New-SelfSignedCertificate -ConfigFile $confPath -OutputDirectory $TestDrive -Confirm:$false
+
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Build-CsrConfig' -Times 0 -Exactly
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Invoke-OpenSsl' -Times 1 -Exactly -ParameterFilter {
+                $configIndex = [System.Array]::IndexOf($ArgumentList, '-config')
+                $configIndex -ge 0 -and $ArgumentList[$configIndex + 1] -eq $confPath
+            }
+        }
+
+        It 'Derives the artifact basename from the CN line in the config file' {
+            $confPath = Join-Path $TestDrive 'custom.conf'
+            Set-Content -Path $confPath -Value @('[req]', 'prompt = no', 'CN = conf.example.com')
+
+            New-SelfSignedCertificate -ConfigFile $confPath -OutputDirectory $TestDrive -Confirm:$false
+
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Invoke-OpenSsl' -Times 1 -Exactly -ParameterFilter {
+                $joined = $ArgumentList -join ' '
+                ($joined -match 'conf\.example\.com\.pem') -and
+                ($joined -match 'conf\.example\.com_PRIVATE\.key')
+            }
+        }
+
+        It 'Rejects a config file with the wrong extension' {
+            $bad = Join-Path $TestDrive 'custom.txt'
+            Set-Content -Path $bad -Value 'placeholder'
+            { New-SelfSignedCertificate -ConfigFile $bad -OutputDirectory $TestDrive -Confirm:$false } | Should -Throw
+        }
+    }
+
+    Context 'ShouldProcess' {
+
+        It 'Skips Invoke-OpenSsl under -WhatIf' {
+            New-SelfSignedCertificate -CommonName 'test.example.com' -OutputDirectory $TestDrive -WhatIf
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Invoke-OpenSsl' -Times 0 -Exactly
+        }
+    }
+}

--- a/Tests/Unit/Test-Cipher.Tests.ps1
+++ b/Tests/Unit/Test-Cipher.Tests.ps1
@@ -1,0 +1,120 @@
+BeforeDiscovery {
+    # Pester evaluates -Skip during discovery, before BeforeAll runs, so
+    # the openssl probe must live here. The -Cipher ValidateScript on
+    # Test-Cipher calls `openssl ciphers` directly (not via the module's
+    # Invoke-OpenSsl wrapper), so the local openssl must be on PATH.
+    $script:opensslAvailable = [bool] (Get-Command -Name 'openssl' -CommandType Application -ErrorAction SilentlyContinue)
+}
+
+BeforeAll {
+    $manifestPath = if ($env:BHPSModuleManifest) {
+        $env:BHPSModuleManifest
+    }
+    else {
+        Join-Path -Path $PSScriptRoot -ChildPath '..\..\PS.SSL.psd1' | Resolve-Path | Select-Object -ExpandProperty Path
+    }
+    Get-Module -Name 'PS.SSL' -All | Remove-Module -Force -ErrorAction SilentlyContinue
+    Import-Module -Name $manifestPath -Force
+
+    # Pick the first cipher openssl reports so the test is portable across
+    # openssl versions and FIPS builds. Discovery-scope variables aren't
+    # visible to It bodies, so the value is resolved again here at runtime.
+    $script:validCipher = ((& openssl ciphers 2>$null) -split ':')[0]
+
+    # Indirect the test target through a variable so PSScriptAnalyzer's
+    # PSAvoidUsingComputerNameHardcoded rule does not fire on test code
+    # that never reaches a real network endpoint (Invoke-OpenSsl is mocked).
+    $script:testHost = 'example.com'
+}
+
+Describe 'Test-Cipher' -Skip:(-not $script:opensslAvailable) {
+
+    BeforeEach {
+        Mock -ModuleName PS.SSL Invoke-OpenSsl {
+            [PSCustomObject] @{ ExitCode = 0; StdOut = 'handshake ok'; StdErr = '' }
+        }
+    }
+
+    Context 'Parameter validation' {
+
+        It 'Rejects an empty ComputerName' {
+            { Test-Cipher -ComputerName ([string]::Empty) -Cipher $script:validCipher } | Should -Throw
+        }
+
+        It 'Rejects an out-of-range Port' {
+            { Test-Cipher -ComputerName $script:testHost -Port 70000 -Cipher $script:validCipher } | Should -Throw
+        }
+
+        It 'Rejects a cipher not in the local openssl cipher list' {
+            { Test-Cipher -ComputerName $script:testHost -Cipher 'NOT-A-REAL-CIPHER-XYZ' } | Should -Throw
+        }
+    }
+
+    Context 'OpenSSL invocation' {
+
+        It 'Calls openssl s_client with -cipher and -connect host:port' {
+            Test-Cipher -ComputerName $script:testHost -Port 443 -Cipher $script:validCipher | Out-Null
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Invoke-OpenSsl' -Times 1 -Exactly -ParameterFilter {
+                ($ArgumentList -contains 's_client')   -and
+                ($ArgumentList -contains '-cipher')    -and
+                ($ArgumentList -contains '-connect')
+            }
+        }
+
+        It 'Forms the -connect endpoint as host:port' {
+            Test-Cipher -ComputerName $script:testHost -Port 8443 -Cipher $script:validCipher | Out-Null
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Invoke-OpenSsl' -Times 1 -Exactly -ParameterFilter {
+                $connectIndex = [System.Array]::IndexOf($ArgumentList, '-connect')
+                $connectIndex -ge 0 -and $ArgumentList[$connectIndex + 1] -eq 'example.com:8443'
+            }
+        }
+
+        It 'Defaults to port 443 when -Port is not supplied' {
+            Test-Cipher -ComputerName $script:testHost -Cipher $script:validCipher | Out-Null
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Invoke-OpenSsl' -Times 1 -Exactly -ParameterFilter {
+                $connectIndex = [System.Array]::IndexOf($ArgumentList, '-connect')
+                $connectIndex -ge 0 -and $ArgumentList[$connectIndex + 1] -eq 'example.com:443'
+            }
+        }
+
+        It 'Uses -IgnoreExitCode so a rejected cipher is non-terminating' {
+            Test-Cipher -ComputerName $script:testHost -Cipher $script:validCipher | Out-Null
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Invoke-OpenSsl' -Times 1 -Exactly -ParameterFilter {
+                $IgnoreExitCode -eq $true
+            }
+        }
+    }
+
+    Context 'Structured output contract' {
+
+        It 'Returns a PSCustomObject with the full property set' {
+            $result = Test-Cipher -ComputerName $script:testHost -Cipher $script:validCipher
+            $result | Should -BeOfType ([pscustomobject])
+            foreach ($prop in 'ComputerName', 'Port', 'Cipher', 'Supported', 'Error') {
+                $result.PSObject.Properties.Name | Should -Contain $prop
+            }
+        }
+
+        It 'Sets Supported=$true and Error=$null on ExitCode 0' {
+            $result = Test-Cipher -ComputerName $script:testHost -Cipher $script:validCipher
+            $result.Supported | Should -BeTrue
+            $result.Error     | Should -BeNullOrEmpty
+        }
+
+        It 'Sets Supported=$false and surfaces trimmed stderr on non-zero exit' {
+            Mock -ModuleName PS.SSL Invoke-OpenSsl {
+                [PSCustomObject] @{ ExitCode = 1; StdOut = ''; StdErr = "  handshake failure  `n" }
+            }
+            $result = Test-Cipher -ComputerName $script:testHost -Cipher $script:validCipher
+            $result.Supported | Should -BeFalse
+            $result.Error     | Should -Be 'handshake failure'
+        }
+
+        It 'Echoes ComputerName, Port, and Cipher to the output object verbatim' {
+            $result = Test-Cipher -ComputerName $script:testHost -Port 8443 -Cipher $script:validCipher
+            $result.ComputerName | Should -Be 'example.com'
+            $result.Port         | Should -Be 8443
+            $result.Cipher       | Should -Be $script:validCipher
+        }
+    }
+}

--- a/Tests/Unit/Test-Protocol.Tests.ps1
+++ b/Tests/Unit/Test-Protocol.Tests.ps1
@@ -1,0 +1,134 @@
+BeforeAll {
+    $manifestPath = if ($env:BHPSModuleManifest) {
+        $env:BHPSModuleManifest
+    }
+    else {
+        Join-Path -Path $PSScriptRoot -ChildPath '..\..\PS.SSL.psd1' | Resolve-Path | Select-Object -ExpandProperty Path
+    }
+    Get-Module -Name 'PS.SSL' -All | Remove-Module -Force -ErrorAction SilentlyContinue
+    Import-Module -Name $manifestPath -Force
+
+    # Indirect the test target through a variable so PSScriptAnalyzer's
+    # PSAvoidUsingComputerNameHardcoded rule does not fire on test code
+    # that never reaches a real network endpoint (Invoke-OpenSsl is mocked).
+    $script:testHost = 'example.com'
+}
+
+Describe 'Test-Protocol' {
+
+    BeforeEach {
+        Mock -ModuleName PS.SSL Invoke-OpenSsl {
+            [PSCustomObject] @{ ExitCode = 0; StdOut = 'handshake ok'; StdErr = '' }
+        }
+    }
+
+    Context 'Parameter validation' {
+
+        It 'Rejects an empty ComputerName' {
+            { Test-Protocol -ComputerName ([string]::Empty) -Protocol 'TLS 1.2' } | Should -Throw
+        }
+
+        It 'Rejects an out-of-range Port' {
+            { Test-Protocol -ComputerName $script:testHost -Port 70000 -Protocol 'TLS 1.2' } | Should -Throw
+        }
+
+        It 'Rejects a Protocol value not in the ValidateSet' {
+            { Test-Protocol -ComputerName $script:testHost -Protocol 'SSLv3' } | Should -Throw
+        }
+    }
+
+    Context 'OpenSSL invocation' {
+
+        It 'Calls openssl s_client with -connect host:port' {
+            Test-Protocol -ComputerName $script:testHost -Port 443 -Protocol 'TLS 1.2' | Out-Null
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Invoke-OpenSsl' -Times 1 -Exactly -ParameterFilter {
+                ($ArgumentList -contains 's_client') -and
+                ($ArgumentList -contains '-connect')
+            }
+        }
+
+        It 'Forms the -connect endpoint as host:port' {
+            Test-Protocol -ComputerName $script:testHost -Port 8443 -Protocol 'TLS 1.2' | Out-Null
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Invoke-OpenSsl' -Times 1 -Exactly -ParameterFilter {
+                $connectIndex = [System.Array]::IndexOf($ArgumentList, '-connect')
+                $connectIndex -ge 0 -and $ArgumentList[$connectIndex + 1] -eq 'example.com:8443'
+            }
+        }
+
+        It 'Defaults to port 443 when -Port is not supplied' {
+            Test-Protocol -ComputerName $script:testHost -Protocol 'TLS 1.2' | Out-Null
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Invoke-OpenSsl' -Times 1 -Exactly -ParameterFilter {
+                $connectIndex = [System.Array]::IndexOf($ArgumentList, '-connect')
+                $connectIndex -ge 0 -and $ArgumentList[$connectIndex + 1] -eq 'example.com:443'
+            }
+        }
+
+        It 'Uses -IgnoreExitCode so a rejected protocol is non-terminating' {
+            Test-Protocol -ComputerName $script:testHost -Protocol 'TLS 1.2' | Out-Null
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Invoke-OpenSsl' -Times 1 -Exactly -ParameterFilter {
+                $IgnoreExitCode -eq $true
+            }
+        }
+
+        It 'Maps "TLS 1.0" to the -tls1 switch' {
+            Test-Protocol -ComputerName $script:testHost -Protocol 'TLS 1.0' | Out-Null
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Invoke-OpenSsl' -Times 1 -Exactly -ParameterFilter {
+                $ArgumentList -contains '-tls1'
+            }
+        }
+
+        It 'Maps "TLS 1.1" to the -tls1_1 switch' {
+            Test-Protocol -ComputerName $script:testHost -Protocol 'TLS 1.1' | Out-Null
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Invoke-OpenSsl' -Times 1 -Exactly -ParameterFilter {
+                $ArgumentList -contains '-tls1_1'
+            }
+        }
+
+        It 'Maps "TLS 1.2" to the -tls1_2 switch' {
+            Test-Protocol -ComputerName $script:testHost -Protocol 'TLS 1.2' | Out-Null
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Invoke-OpenSsl' -Times 1 -Exactly -ParameterFilter {
+                $ArgumentList -contains '-tls1_2'
+            }
+        }
+
+        It 'Maps "TLS 1.3" to the -tls1_3 switch' {
+            Test-Protocol -ComputerName $script:testHost -Protocol 'TLS 1.3' | Out-Null
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Invoke-OpenSsl' -Times 1 -Exactly -ParameterFilter {
+                $ArgumentList -contains '-tls1_3'
+            }
+        }
+    }
+
+    Context 'Structured output contract' {
+
+        It 'Returns a PSCustomObject with the full property set' {
+            $result = Test-Protocol -ComputerName $script:testHost -Protocol 'TLS 1.2'
+            $result | Should -BeOfType ([pscustomobject])
+            foreach ($prop in 'ComputerName', 'Port', 'Protocol', 'Supported', 'Error') {
+                $result.PSObject.Properties.Name | Should -Contain $prop
+            }
+        }
+
+        It 'Sets Supported=$true and Error=$null on ExitCode 0' {
+            $result = Test-Protocol -ComputerName $script:testHost -Protocol 'TLS 1.2'
+            $result.Supported | Should -BeTrue
+            $result.Error     | Should -BeNullOrEmpty
+        }
+
+        It 'Sets Supported=$false and surfaces trimmed stderr on non-zero exit' {
+            Mock -ModuleName PS.SSL Invoke-OpenSsl {
+                [PSCustomObject] @{ ExitCode = 1; StdOut = ''; StdErr = "  no protocols available  `n" }
+            }
+            $result = Test-Protocol -ComputerName $script:testHost -Protocol 'TLS 1.0'
+            $result.Supported | Should -BeFalse
+            $result.Error     | Should -Be 'no protocols available'
+        }
+
+        It 'Echoes ComputerName, Port, and Protocol to the output object verbatim' {
+            $result = Test-Protocol -ComputerName $script:testHost -Port 8443 -Protocol 'TLS 1.3'
+            $result.ComputerName | Should -Be 'example.com'
+            $result.Port         | Should -Be 8443
+            $result.Protocol     | Should -Be 'TLS 1.3'
+        }
+    }
+}

--- a/examples/GenerateCSR.ps1
+++ b/examples/GenerateCSR.ps1
@@ -55,7 +55,7 @@ New-CSR -OutputDirectory $root -ConfigFile "$root\template.conf"
 
 
 # VERIFY UNSIGNED CSR ATTRIBUTES
-Get-CSRData -CSR "$root\www.company.com.csr"
+Get-CSRData -Path "$root\www.company.com.csr"
 
 
 #region GENERATE PFX ===========================================================
@@ -73,12 +73,12 @@ Get-CertificateData -Path "$root\digicert\TrustedRoot.crt"
 
 # COMPLETE PROCESS BY EXPORTING PFX/P12
 $pfxParams = @{
-    OutputDirectory = "$root\completed"
-    Password        = Read-Host -AsSecureString -Prompt 'Password'
-    SignedCSR       = "$root\digicert\<CERTIFICATE>.crt"
-    Key             = "$root\<PRIVATE_KEY>.key"
-    RootCA          = "$root\digicert\TrustedRoot.crt"
-    IntermediateCA  = "$root\digicert\DigiCertCA.crt"
+    OutputDirectory    = "$root\completed"
+    Password           = Read-Host -AsSecureString -Prompt 'Password'
+    SignedCSRPath      = "$root\digicert\<CERTIFICATE>.crt"
+    KeyPath            = "$root\<PRIVATE_KEY>.key"
+    RootCAPath         = "$root\digicert\TrustedRoot.crt"
+    IntermediateCAPath = "$root\digicert\DigiCertCA.crt"
 }
 Export-PFX @pfxParams
 
@@ -97,8 +97,8 @@ ConvertFrom-PKCS7 -Path "$root\<CERTIFICATE>.pem" -OutputDirectory $root
 $pfxParams = @{
     OutputDirectory = "$root\completed"
     Password        = Read-Host -AsSecureString -Prompt 'Password'
-    SignedCSR       = "$root\digicert\<CERTIFICATE>.crt"
-    Key             = "$root\<PRIVATE_KEY>.key"
+    SignedCSRPath   = "$root\digicert\<CERTIFICATE>.crt"
+    KeyPath         = "$root\<PRIVATE_KEY>.key"
 }
 Export-PFX @pfxParams
 

--- a/examples/GenerateCSR.ps1
+++ b/examples/GenerateCSR.ps1
@@ -43,7 +43,7 @@ New-CSR @csrParams
 $root = "$HOME\Desktop\test\CSR"
 
 # CREATE EXAMPLE TEMPLATE IN ROOT
-$CSR_Template | Set-Content -Path "$root\template.conf"
+Get-CSRTemplate | Set-Content -Path "$root\template.conf"
 
 # OPEN THE CONFIG FILE AND EDIT THE REQUIRED PROPERTIES
 code "$root\template.conf"

--- a/examples/setup.ps1
+++ b/examples/setup.ps1
@@ -1,34 +1,100 @@
 <# =============================================================================
 .DESCRIPTION
-    This script is intended to help configure an environment to use PS.SSL
+    One-shot bootstrapper for a fresh PS.SSL environment. Installs openssl
+    using the appropriate package manager for the current OS, clones the
+    module into the user-scope PowerShell modules folder, and copies the
+    example scripts next to the user's home directory for quick exploration.
 .NOTES
-    General notes
+    Status: Stable
+
+    - Requires PowerShell 7.0 or later (uses $IsWindows / $IsMacOS / $IsLinux).
+    - Idempotent: skips openssl install when already on PATH; skips git clone
+      when the destination already exists.
+    - Windows openssl install uses winget. macOS uses Homebrew. Linux uses
+      apt-get when present, otherwise dnf, otherwise prints a manual hint.
 ============================================================================= #>
 
-# SET VARIABLS
-$moduleUrl = 'https://github.com/johnsarie27/PS.SSL/archive/refs/heads/main.zip'
-$moduleFolder = "$HOME\Documents\PowerShell\Modules"
+#requires -Version 7.0
 
-# STEP 1: INSTALL OPENSSL
-winget install --Id ShiningLight.OpenSSL --silent --accept-source-agreements --accept-package-agreements
+[CmdletBinding()]
+param ()
 
-# STEP 2: DOWNLOAD COMPRESSED MODULE
-Invoke-WebRequest -Uri $moduleUrl -OutFile "$HOME\Desktop\PS.SSL.zip"
+$ErrorActionPreference = 'Stop'
 
-# STEP 3: EXPAND PS.SSL TO PS 7 MODULES FOLDER
-Expand-Archive -Path "$HOME\Desktop\PS.SSL.zip" -DestinationPath $moduleFolder
+# -----------------------------------------------------------------------------
+# STEP 1: Install openssl (skip when already on PATH)
+# -----------------------------------------------------------------------------
+if (Get-Command -Name 'openssl' -CommandType Application -ErrorAction SilentlyContinue) {
+    Write-Verbose -Message 'openssl already on PATH; skipping install.'
+}
+elseif ($IsWindows) {
+    if (-not (Get-Command -Name 'winget' -CommandType Application -ErrorAction SilentlyContinue)) {
+        Write-Error -Message 'winget not found. Install App Installer from the Microsoft Store or install openssl manually.' -ErrorAction Stop
+    }
+    $wingetArgs = @(
+        'install', '--Id', 'ShiningLight.OpenSSL',
+        '--silent', '--accept-source-agreements', '--accept-package-agreements'
+    )
+    & winget @wingetArgs
+}
+elseif ($IsMacOS) {
+    if (-not (Get-Command -Name 'brew' -CommandType Application -ErrorAction SilentlyContinue)) {
+        Write-Error -Message 'Homebrew not found. Install from https://brew.sh and re-run this script.' -ErrorAction Stop
+    }
+    & brew install 'openssl@3'
+}
+elseif ($IsLinux) {
+    if (Get-Command -Name 'apt-get' -CommandType Application -ErrorAction SilentlyContinue) {
+        & sudo apt-get update
+        & sudo apt-get install -y openssl
+    }
+    elseif (Get-Command -Name 'dnf' -CommandType Application -ErrorAction SilentlyContinue) {
+        & sudo dnf install -y openssl
+    }
+    else {
+        Write-Error -Message 'No supported package manager (apt-get, dnf) detected. Install openssl manually and re-run.' -ErrorAction Stop
+    }
+}
+else {
+    Write-Error -Message 'Unsupported operating system.' -ErrorAction Stop
+}
 
-# STEP 4: GET VERSION AND RENAME MODULE FOLDER
-Rename-Item -Path "$moduleFolder\PS.SSL-main" -NewName "PS.SSL"
+# -----------------------------------------------------------------------------
+# STEP 2: Clone PS.SSL into the first entry of $env:PSModulePath
+# -----------------------------------------------------------------------------
+if (-not (Get-Command -Name 'git' -CommandType Application -ErrorAction SilentlyContinue)) {
+    Write-Error -Message 'git not found on PATH. Install git and re-run this script.' -ErrorAction Stop
+}
 
-# STEP 5: UNBLOCK NEW MODULE
-Get-ChildItem -Path "$moduleFolder\PS.SSL" -Recurse | Unblock-File
+$moduleParent = ($env:PSModulePath -split [System.IO.Path]::PathSeparator)[0]
+$modulePath = Join-Path -Path $moduleParent -ChildPath 'PS.SSL'
 
-# STEP 6: COPY EXAMPLE FILES TO DESKTOP
-Copy-Item -Path "$moduleFolder\PS.SSL\examples" -Destination "$HOME\Desktop\ps.ssl-examples" -Recurse
+if (-not (Test-Path -Path $moduleParent)) {
+    New-Item -Path $moduleParent -ItemType Directory -Force | Out-Null
+}
 
-# STEP 7: CLEANUP ARTIFACTS
-Remove-Item -Path "$HOME\Desktop\PS.SSL.zip"
+if (Test-Path -Path $modulePath) {
+    Write-Verbose -Message "PS.SSL already present at [$modulePath]; skipping clone."
+}
+else {
+    & git clone 'https://github.com/johnsarie27/PS.SSL.git' $modulePath
+}
 
-# TEST SCRIPT
-code "$HOME\Desktop\ps.ssl-examples\GenerateCSR.ps1"
+# -----------------------------------------------------------------------------
+# STEP 3: Copy examples next to the user's home folder for easy access
+# -----------------------------------------------------------------------------
+$examplesSource = Join-Path -Path $modulePath -ChildPath 'examples'
+$examplesDestination = Join-Path -Path $HOME -ChildPath 'ps.ssl-examples'
+
+if (Test-Path -Path $examplesDestination) {
+    Write-Verbose -Message "Examples folder already exists at [$examplesDestination]; skipping copy."
+}
+else {
+    Copy-Item -Path $examplesSource -Destination $examplesDestination -Recurse
+}
+
+Write-Output ''
+Write-Output "PS.SSL installed at:  $modulePath"
+Write-Output "Example scripts at:   $examplesDestination"
+Write-Output ''
+Write-Output 'Next: Import-Module PS.SSL ; Get-Command -Module PS.SSL'

--- a/examples/setup.ps1
+++ b/examples/setup.ps1
@@ -10,7 +10,7 @@ $moduleUrl = 'https://github.com/johnsarie27/PS.SSL/archive/refs/heads/main.zip'
 $moduleFolder = "$HOME\Documents\PowerShell\Modules"
 
 # STEP 1: INSTALL OPENSSL
-choco install openssl -y
+winget install --Id ShiningLight.OpenSSL --silent --accept-source-agreements --accept-package-agreements
 
 # STEP 2: DOWNLOAD COMPRESSED MODULE
 Invoke-WebRequest -Uri $moduleUrl -OutFile "$HOME\Desktop\PS.SSL.zip"


### PR DESCRIPTION
## Summary

Module-wide refactor addressing correctness, security, architecture, and consistency findings from a full code review of PS.SSL. Work is being merged incrementally on this branch; each commit references the relevant tracked item via `(refs #35, item Nx)`.

**Live per-item checklist lives on issue #35** — that issue is the source of truth for what is done and what is outstanding. This PR body intentionally stays slim and only flags reviewer-relevant context.

## Breaking changes

- **`Get-CertificateData`** now returns `[X509Certificate2]` (constructed from openssl-normalized DER bytes) instead of a text blob. (`6ae74c7`)
- **`Get-CSRData`** now returns a `[pscustomobject]` with `Path`, `Subject`, `PublicKeyAlgorithm`, `PublicKeyBits`, `SignatureAlgorithm`, `SubjectAlternativeName` (`string[]`), `Verified` (bool), `Raw` (the full openssl text, preserved for callers that still want it). (`6ae74c7`)
- Path parameter rename on `ConvertTo-PEM`, `Get-CSRData`, `Export-PFX` to canonical `-Path` / `<Thing>Path`. Legacy parameter names (`-PFX`, `-CSR`, `-Key`, `-SignedCSR`, `-RootCA`, `-IntermediateCA`) are preserved as `[Alias()]` so existing callers continue to work without change. (`5aaf353`)

No other public surface breakage. The `[Alias()]` cover should keep existing scripts working; binary-or-pipeline consumers of the two changed return types will need to update.

## How to validate

- `Invoke-ScriptAnalyzer -Path .\Public -Settings .\Build\PSScriptAnalyzerSettings.psd1 -Recurse` — must be clean.
- `Invoke-ScriptAnalyzer -Path .\Private -Settings .\Build\PSScriptAnalyzerSettings.psd1 -Recurse` — must be clean.
- `Invoke-Pester -Path .\Tests` for the common Help / Manifest / Meta tests.
- Targeted smoke patterns for each item are documented in the commit message of the commit that landed it.

## Notable internals introduced on this branch

- `Private/Invoke-OpenSsl.ps1` — single execution point for all 9 public openssl call sites; captures stdout/stderr and surfaces non-zero exits.
- `Private/Build-CsrConfig.ps1` — shared CSR/SSC template rendering.
- `Private/Initialize-OutputDirectory.ps1` + `Private/Test-OutputDirectoryPath.ps1` — paired helpers for `-OutputDirectory` validation (bind-time) and creation (Begin block).

Closes #35
