### PR TITLE
Fix TCP pre-flight timeout for Test-Protocol/Test-Cipher/Test-SSLProtocol (refs #40)

### DIFF
--- a/PS.SSL.psd1
+++ b/PS.SSL.psd1
@@ -9,6 +9,9 @@
     RootModule        = 'PS.SSL.psm1'
 
     # Version number of this module.
+    # Major = significant changes, breaking changes or major new features
+    # Minor = new functions or features
+    # Build = bug fixes and minor updates
     ModuleVersion     = '0.3.1'
 
     # Supported PSEditions

--- a/PS.SSL.psd1
+++ b/PS.SSL.psd1
@@ -9,7 +9,7 @@
     RootModule        = 'PS.SSL.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '0.3.0'
+    ModuleVersion     = '0.3.1'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/Private/Test-TcpConnection.ps1
+++ b/Private/Test-TcpConnection.ps1
@@ -1,0 +1,77 @@
+function Test-TcpConnection {
+    <#
+    .SYNOPSIS
+        Probe TCP reachability of a remote endpoint with a bounded timeout.
+    .DESCRIPTION
+        Internal helper used by the SSL/TLS probing cmdlets (Test-Protocol,
+        Test-Cipher, Test-SSLProtocol) to short-circuit when the target
+        endpoint is unreachable. openssl s_client and System.Net.Sockets.Socket
+        both iterate through every DNS A record sequentially using the OS
+        default connect timeout (~21s/address on Windows), which produces
+        90+ second hangs when a host resolves to many addresses that drop
+        traffic (typical on corp networks with split-horizon DNS).
+
+        TcpClient.ConnectAsync still walks every resolved address internally,
+        but Task.Wait(TimeoutMilliseconds) caps the total wall-clock time
+        we'll spend waiting regardless of how many addresses are tried.
+    .PARAMETER ComputerName
+        Target host name or IP.
+    .PARAMETER Port
+        TCP port.
+    .PARAMETER TimeoutMilliseconds
+        Maximum total time to wait for a successful connect, in milliseconds.
+        Defaults to 3000.
+    .INPUTS
+        None.
+    .OUTPUTS
+        System.Boolean. $true if a TCP connection was established within the
+        timeout window; otherwise $false.
+    .EXAMPLE
+        PS C:\> Test-TcpConnection -ComputerName example.com -Port 443 -TimeoutMilliseconds 3000
+    .NOTES
+        Status: Stable
+        - Internal helper. Not exported from the module.
+    #>
+    [CmdletBinding()]
+    [OutputType([System.Boolean])]
+    Param(
+        [Parameter(Mandatory, Position = 0, HelpMessage = 'Target host name or IP')]
+        [ValidateNotNullOrEmpty()]
+        [System.String] $ComputerName,
+
+        [Parameter(Mandatory, Position = 1, HelpMessage = 'TCP port')]
+        [ValidateRange(0, 65535)]
+        [System.Int32] $Port,
+
+        [Parameter(Position = 2, HelpMessage = 'Maximum total wait, in milliseconds')]
+        [ValidateRange(1, 600000)]
+        [System.Int32] $TimeoutMilliseconds = 3000
+    )
+    Begin {
+        Write-Verbose -Message "Starting $($MyInvocation.MyCommand)"
+    }
+    Process {
+        # TcpClient.ConnectAsync(host, port) resolves the host and attempts
+        # each address in sequence. Task.Wait returns $false if the timeout
+        # elapses before completion; in that case we abandon the in-flight
+        # task by disposing the client (which cancels the underlying socket).
+        $client = [System.Net.Sockets.TcpClient]::new()
+        try {
+            $task = $client.ConnectAsync($ComputerName, $Port)
+            if ($task.Wait($TimeoutMilliseconds)) {
+                return $client.Connected
+            }
+            return $false
+        }
+        catch {
+            # DNS failure, host unreachable mid-attempt, etc. Probe is a
+            # boolean reachability check - swallow the exception and let
+            # the caller treat the endpoint as unreachable.
+            Write-Verbose -Message ('TCP probe of {0}:{1} failed: {2}' -f $ComputerName, $Port, $_.Exception.Message)
+            return $false
+        }
+        finally {
+            $client.Dispose()
+        }
+    }
+}

--- a/Public/Test-Cipher.ps1
+++ b/Public/Test-Cipher.ps1
@@ -12,6 +12,9 @@ function Test-Cipher {
         TCP Port
     .PARAMETER Cipher
         Cipher
+    .PARAMETER TimeoutSeconds
+        Max wait for the TCP pre-flight, in seconds. Bounds total wait when
+        a host resolves to many unresponsive addresses (default: 3).
     .INPUTS
         None.
     .OUTPUTS
@@ -49,17 +52,35 @@ function Test-Cipher {
             }
             $true
         })]
-        [System.String] $Cipher
+        [System.String] $Cipher,
+
+        [Parameter(HelpMessage = 'TCP connect timeout, in seconds')]
+        [ValidateRange(1, 600)]
+        [System.Int32] $TimeoutSeconds = 3
     )
     Begin {
         Write-Verbose -Message "Starting $($MyInvocation.Mycommand)"
     }
     Process {
+        # TCP PRE-FLIGHT. Without this, an unreachable host that resolves to
+        # many addresses (common with split-horizon corp DNS) causes openssl
+        # s_client to walk every address at the OS default connect timeout,
+        # producing 90+ second hangs. Bound the wait time and short-circuit.
+        $endpoint = '{0}:{1}' -f $ComputerName, $Port
+        if (-not (Test-TcpConnection -ComputerName $ComputerName -Port $Port -TimeoutMilliseconds ($TimeoutSeconds * 1000))) {
+            return [PSCustomObject] @{
+                ComputerName = $ComputerName
+                Port         = $Port
+                Cipher       = $Cipher
+                Supported    = $false
+                Error        = ('TCP connect to {0} failed or timed out after {1}s' -f $endpoint, $TimeoutSeconds)
+            }
+        }
+
         # openssl s_client -cipher '<CIPHER>' -connect <host:port>
         # Non-zero exit means the server rejected the cipher; use
         # -IgnoreExitCode so we receive the result object instead of a
         # terminating error and can encode the outcome as Supported=$false.
-        $endpoint = '{0}:{1}' -f $ComputerName, $Port
         $result = Invoke-OpenSsl -ArgumentList @('s_client', '-cipher', $Cipher, '-connect', $endpoint) -IgnoreExitCode
 
         [PSCustomObject] @{

--- a/Public/Test-Protocol.ps1
+++ b/Public/Test-Protocol.ps1
@@ -12,6 +12,9 @@ function Test-Protocol {
         TCP Port
     .PARAMETER Protocol
         Protocol versions
+    .PARAMETER TimeoutSeconds
+        Max wait for the TCP pre-flight, in seconds. Bounds total wait when
+        a host resolves to many unresponsive addresses (default: 3).
     .INPUTS
         None.
     .OUTPUTS
@@ -38,7 +41,11 @@ function Test-Protocol {
 
         [Parameter(Mandatory = $true, Position = 2, HelpMessage = 'Protocol version')]
         [ValidateSet('TLS 1.0','TLS 1.1', 'TLS 1.2', 'TLS 1.3')]
-        [System.String] $Protocol
+        [System.String] $Protocol,
+
+        [Parameter(HelpMessage = 'TCP connect timeout, in seconds')]
+        [ValidateRange(1, 600)]
+        [System.Int32] $TimeoutSeconds = 3
     )
     Begin {
         Write-Verbose -Message "Starting $($MyInvocation.Mycommand)"
@@ -52,11 +59,27 @@ function Test-Protocol {
         }
     }
     Process {
+        # TCP PRE-FLIGHT. Without this, an unreachable host that resolves to
+        # many addresses (common with split-horizon corp DNS) causes openssl
+        # s_client to walk every address at the OS default connect timeout,
+        # producing 90+ second hangs and a stderr cascade of repeated
+        # BIO_connect failures. Bound the wait time here and report a clean
+        # Supported=$false result instead.
+        $endpoint = '{0}:{1}' -f $ComputerName, $Port
+        if (-not (Test-TcpConnection -ComputerName $ComputerName -Port $Port -TimeoutMilliseconds ($TimeoutSeconds * 1000))) {
+            return [PSCustomObject] @{
+                ComputerName = $ComputerName
+                Port         = $Port
+                Protocol     = $Protocol
+                Supported    = $false
+                Error        = ('TCP connect to {0} failed or timed out after {1}s' -f $endpoint, $TimeoutSeconds)
+            }
+        }
+
         # openssl.exe s_client -connect <host:port> -<protocol-switch>
         # Non-zero exit means the server rejected the protocol; use
         # -IgnoreExitCode so we receive the result object instead of a
         # terminating error and can encode the outcome as Supported=$false.
-        $endpoint = '{0}:{1}' -f $ComputerName, $Port
         $protoSwitch = '-{0}' -f $protoHash[$Protocol]
         $result = Invoke-OpenSsl -ArgumentList @('s_client', '-connect', $endpoint, $protoSwitch) -IgnoreExitCode
 

--- a/Public/Test-SSLProtocol.ps1
+++ b/Public/Test-SSLProtocol.ps1
@@ -8,6 +8,10 @@ function Test-SSLProtocol {
         Target Computer System
     .PARAMETER Port
         TCP Port
+    .PARAMETER TimeoutSeconds
+        Max wait for each TCP connect attempt, in seconds. Bounds total
+        wait when a host resolves to many unresponsive addresses
+        (default: 3).
     .INPUTS
         System.String.
     .OUTPUTS
@@ -29,7 +33,11 @@ function Test-SSLProtocol {
 
         [Parameter(Position = 1, HelpMessage = 'TCP Port')]
         [ValidateRange(0, 65535)]
-        [System.Int32] $Port = 443
+        [System.Int32] $Port = 443,
+
+        [Parameter(HelpMessage = 'TCP connect timeout, in seconds')]
+        [ValidateRange(1, 600)]
+        [System.Int32] $TimeoutSeconds = 3
     )
     Begin {
         Write-Verbose -Message "Starting $($MyInvocation.Mycommand)"
@@ -47,12 +55,29 @@ function Test-SSLProtocol {
             SignatureAlgorithm = $null
         }
 
+        # TCP PRE-FLIGHT. If the endpoint is unreachable, record every
+        # protocol as $false up front instead of waiting for Socket.Connect
+        # to walk every DNS A record at the OS default connect timeout.
+        if (-not (Test-TcpConnection -ComputerName $ComputerName -Port $Port -TimeoutMilliseconds ($TimeoutSeconds * 1000))) {
+            Write-Warning -Message ('TCP connect to {0}:{1} failed or timed out after {2}s; reporting all protocols as unsupported.' -f $ComputerName, $Port, $TimeoutSeconds)
+            foreach ($pn in $protoNames) { $protocolStatus.Add($pn, $false) }
+            [PSCustomObject] $protocolStatus
+            return
+        }
+
+        $connectTimeoutMs = $TimeoutSeconds * 1000
         foreach ($pn in $protoNames) {
 
             $socket = $null; $netStream = $null; $sslStream = $null
             try {
                 $socket = New-Object System.Net.Sockets.Socket([System.Net.Sockets.SocketType]::Stream, [System.Net.Sockets.ProtocolType]::Tcp)
-                $socket.Connect($ComputerName, $Port)
+                # Use the async ConnectAsync + Wait pattern to bound the connect
+                # time. Socket.Connect(host, port) has no per-attempt timeout
+                # and iterates DNS results at the OS default (~21s/address).
+                $connectTask = $socket.ConnectAsync($ComputerName, $Port)
+                if (-not $connectTask.Wait($connectTimeoutMs)) {
+                    throw [System.TimeoutException]::new(('TCP connect to {0}:{1} timed out after {2}s' -f $ComputerName, $Port, $TimeoutSeconds))
+                }
                 $netStream = New-Object System.Net.Sockets.NetworkStream($socket, $true)
                 $sslStream = New-Object System.Net.Security.SslStream($netStream, $true)
                 $sslStream.AuthenticateAsClient($ComputerName, $null, $pn, $false )

--- a/Tests/Unit/Test-Cipher.Tests.ps1
+++ b/Tests/Unit/Test-Cipher.Tests.ps1
@@ -33,6 +33,9 @@ Describe 'Test-Cipher' -Skip:(-not $script:opensslAvailable) {
         Mock -ModuleName PS.SSL Invoke-OpenSsl {
             [PSCustomObject] @{ ExitCode = 0; StdOut = 'handshake ok'; StdErr = '' }
         }
+        # Default the TCP pre-flight to success so the suite never touches the
+        # real network. The dedicated short-circuit context overrides this.
+        Mock -ModuleName PS.SSL Test-TcpConnection { $true }
     }
 
     Context 'Parameter validation' {
@@ -115,6 +118,38 @@ Describe 'Test-Cipher' -Skip:(-not $script:opensslAvailable) {
             $result.ComputerName | Should -Be 'example.com'
             $result.Port         | Should -Be 8443
             $result.Cipher       | Should -Be $script:validCipher
+        }
+    }
+
+    Context 'TCP pre-flight short-circuit' {
+
+        BeforeEach {
+            Mock -ModuleName PS.SSL Test-TcpConnection { $false }
+        }
+
+        It 'Skips Invoke-OpenSsl when the TCP probe fails' {
+            Test-Cipher -ComputerName $script:testHost -Cipher $script:validCipher | Out-Null
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Invoke-OpenSsl' -Times 0 -Exactly
+        }
+
+        It 'Returns Supported=$false with a timeout error message' {
+            $result = Test-Cipher -ComputerName $script:testHost -Cipher $script:validCipher
+            $result.Supported | Should -BeFalse
+            $result.Error    | Should -Match 'TCP connect to example.com:443 (failed|timed out)'
+        }
+
+        It 'Passes -TimeoutSeconds (in ms) to the TCP probe' {
+            Test-Cipher -ComputerName $script:testHost -Cipher $script:validCipher -TimeoutSeconds 7 | Out-Null
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Test-TcpConnection' -Times 1 -Exactly -ParameterFilter {
+                $TimeoutMilliseconds -eq 7000
+            }
+        }
+
+        It 'Defaults TimeoutSeconds to 3 (3000ms) when not supplied' {
+            Test-Cipher -ComputerName $script:testHost -Cipher $script:validCipher | Out-Null
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Test-TcpConnection' -Times 1 -Exactly -ParameterFilter {
+                $TimeoutMilliseconds -eq 3000
+            }
         }
     }
 }

--- a/Tests/Unit/Test-Protocol.Tests.ps1
+++ b/Tests/Unit/Test-Protocol.Tests.ps1
@@ -20,6 +20,9 @@ Describe 'Test-Protocol' {
         Mock -ModuleName PS.SSL Invoke-OpenSsl {
             [PSCustomObject] @{ ExitCode = 0; StdOut = 'handshake ok'; StdErr = '' }
         }
+        # Default the TCP pre-flight to success so the suite never touches the
+        # real network. The dedicated short-circuit context overrides this.
+        Mock -ModuleName PS.SSL Test-TcpConnection { $true }
     }
 
     Context 'Parameter validation' {
@@ -129,6 +132,38 @@ Describe 'Test-Protocol' {
             $result.ComputerName | Should -Be 'example.com'
             $result.Port         | Should -Be 8443
             $result.Protocol     | Should -Be 'TLS 1.3'
+        }
+    }
+
+    Context 'TCP pre-flight short-circuit' {
+
+        BeforeEach {
+            Mock -ModuleName PS.SSL Test-TcpConnection { $false }
+        }
+
+        It 'Skips Invoke-OpenSsl when the TCP probe fails' {
+            Test-Protocol -ComputerName $script:testHost -Protocol 'TLS 1.2' | Out-Null
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Invoke-OpenSsl' -Times 0 -Exactly
+        }
+
+        It 'Returns Supported=$false with a timeout error message' {
+            $result = Test-Protocol -ComputerName $script:testHost -Protocol 'TLS 1.2'
+            $result.Supported | Should -BeFalse
+            $result.Error    | Should -Match 'TCP connect to example.com:443 (failed|timed out)'
+        }
+
+        It 'Passes -TimeoutSeconds (in ms) to the TCP probe' {
+            Test-Protocol -ComputerName $script:testHost -Protocol 'TLS 1.2' -TimeoutSeconds 7 | Out-Null
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Test-TcpConnection' -Times 1 -Exactly -ParameterFilter {
+                $TimeoutMilliseconds -eq 7000
+            }
+        }
+
+        It 'Defaults TimeoutSeconds to 3 (3000ms) when not supplied' {
+            Test-Protocol -ComputerName $script:testHost -Protocol 'TLS 1.2' | Out-Null
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Test-TcpConnection' -Times 1 -Exactly -ParameterFilter {
+                $TimeoutMilliseconds -eq 3000
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #40.

## Problem
`Test-Protocol`, `Test-Cipher`, and `Test-SSLProtocol` hang for 90+ seconds against hosts whose DNS resolves to many unresponsive addresses (e.g. `esri.com` from a corp split-horizon DNS resolving to 17 internal RFC1918 IPs). Both `openssl s_client` and `Socket.Connect` walk every A record at the OS default TCP connect timeout (~21s/address).

## Fix
- New private helper `Test-TcpConnection` uses `TcpClient.ConnectAsync` + `Task.Wait(timeoutMs)` to bound total wall-clock wait regardless of DNS record count.
- `Test-Protocol` / `Test-Cipher`: TCP pre-flight before invoking openssl; short-circuit to `Supported=$false` with a clear error on failure. New `-TimeoutSeconds` parameter (default 3).
- `Test-SSLProtocol`: TCP pre-flight up front (warns, reports every protocol as `$false`); per-protocol loop switched from synchronous `Socket.Connect` to `ConnectAsync` + `Wait($timeoutMs)`. New `-TimeoutSeconds` parameter (default 3).

## Tests
- `Tests/Unit/Test-Protocol.Tests.ps1` and `Tests/Unit/Test-Cipher.Tests.ps1`: mock `Test-TcpConnection` in `BeforeEach` to keep suites hermetic; new `TCP pre-flight short-circuit` context covers the skip path, error message, and `-TimeoutSeconds` → milliseconds propagation.
- 34/34 tests pass locally.

## Manual verification
| Scenario | Before | After |
| --- | --- | --- |
| `Test-Protocol -ComputerName esri.com -Protocol 'TLS 1.2'` | ~90s hang + BIO_connect cascade | ~3s, `Supported=$false`, `Error="TCP connect to esri.com:443 ... timed out after 3s"` |
| `Test-Protocol -ComputerName www.google.com -Protocol 'TLS 1.2'` | ~1.8s, `Supported=$true` | ~1.8s, `Supported=$true` (no regression) |
| `Test-SSLProtocol -ComputerName esri.com` | hangs | ~3s, warning + all protocols `$false` |
