### PR TITLE
feat: enumerate all certs in PEM bundles (issue #39)

### DIFF
--- a/PS.SSL.psd1
+++ b/PS.SSL.psd1
@@ -12,7 +12,7 @@
     # Major = significant changes, breaking changes or major new features
     # Minor = new functions or features
     # Build = bug fixes and minor updates
-    ModuleVersion     = '0.3.1'
+    ModuleVersion     = '0.3.2'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/Public/Get-CertificateData.ps1
+++ b/Public/Get-CertificateData.ps1
@@ -24,11 +24,20 @@ function Get-CertificateData {
     .EXAMPLE
         PS C:\> (Get-CertificateData -Path .\example.pem).Extensions | Where-Object { $_.Oid.Value -eq '2.5.29.17' } | ForEach-Object { $_.Format($true) }
         Print the Subject Alternative Name extension in human-readable form.
+    .EXAMPLE
+        PS C:\> Get-CertificateData -Path .\fullchain.pem | Select-Object Subject
+        Enumerate all certificates in a PEM bundle (leaf + intermediates + root).
+    .EXAMPLE
+        PS C:\> (Get-CertificateData -Path .\fullchain.pem).Count
+        Returns the number of certificates in the bundle.
     .NOTES
         Status: Beta
-        - PEM files containing multiple concatenated certificates (e.g.
-          fullchain.pem) are reduced to the FIRST certificate only. This
-          matches the previous behavior of `openssl x509 -text -noout`.
+        - PEM bundles containing multiple concatenated certificates (e.g.
+          fullchain.pem) are fully enumerated: one X509Certificate2 object
+          is emitted per BEGIN CERTIFICATE block. Wrap in @(...) if you need
+          array semantics when the file may contain only one certificate.
+        - DER-encoded files (.crt, .cer) and single-certificate PEM files
+          each emit exactly one object, preserving prior behavior.
         - openssl is used solely as a format-normalizer here; .NET's PEM
           file loaders (X509Certificate2.CreateFromPemFile) require .NET 5+
           and the module manifest declares PS 7.0 / .NET Core 3.1.
@@ -54,22 +63,42 @@ function Get-CertificateData {
         Write-Verbose -Message "Starting $($MyInvocation.Mycommand)"
     }
     Process {
-        # Normalize PEM/CRT/CER input to DER bytes via openssl. We write to a
-        # temp file rather than capturing DER bytes from stdout because the
-        # Invoke-OpenSsl helper captures StdOut as a string, which would
-        # corrupt binary content.
-        $derPath = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ('pssl-cert-{0}.der' -f [System.Guid]::NewGuid().Guid.Substring(0, 8))
-        try {
-            $sslParams = @{
-                ArgumentList = @('x509', '-in', $Path, '-outform', 'DER', '-out', $derPath)
-            }
-            [System.Void] (Invoke-OpenSsl @sslParams)
+        # Scan for PEM certificate blocks. This handles both single-cert files
+        # and bundles (e.g. fullchain.pem). DER files produce zero matches and
+        # fall through to the single-cert path unchanged.
+        $pemPattern = '-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----'
+        $blocks = [System.Text.RegularExpressions.Regex]::Matches(
+            [System.IO.File]::ReadAllText($Path), $pemPattern)
 
-            $bytes = [System.IO.File]::ReadAllBytes($derPath)
-            [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($bytes)
+        if ($blocks.Count -le 1) {
+            # Single cert or DER format — original behavior preserved.
+            $derPath = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ('pssl-cert-{0}.der' -f [System.Guid]::NewGuid().Guid.Substring(0, 8))
+            try {
+                [System.Void] (Invoke-OpenSsl -ArgumentList @('x509', '-in', $Path, '-outform', 'DER', '-out', $derPath))
+                [System.Security.Cryptography.X509Certificates.X509Certificate2]::new(
+                    [System.IO.File]::ReadAllBytes($derPath))
+            }
+            finally {
+                if (Test-Path -Path $derPath) { Remove-Item -Path $derPath -Force -ErrorAction SilentlyContinue }
+            }
         }
-        finally {
-            if (Test-Path -Path $derPath) { Remove-Item -Path $derPath -Force -ErrorAction SilentlyContinue }
+        else {
+            # PEM bundle — emit one X509Certificate2 per block to the pipeline.
+            Write-Verbose -Message "Found $($blocks.Count) certificates in '$Path'"
+            foreach ($block in $blocks) {
+                $tempPem = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ('pssl-cert-{0}.pem' -f [System.Guid]::NewGuid().Guid.Substring(0, 8))
+                $derPath = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ('pssl-cert-{0}.der' -f [System.Guid]::NewGuid().Guid.Substring(0, 8))
+                try {
+                    [System.IO.File]::WriteAllText($tempPem, $block.Value)
+                    [System.Void] (Invoke-OpenSsl -ArgumentList @('x509', '-in', $tempPem, '-outform', 'DER', '-out', $derPath))
+                    [System.Security.Cryptography.X509Certificates.X509Certificate2]::new(
+                        [System.IO.File]::ReadAllBytes($derPath))
+                }
+                finally {
+                    if (Test-Path -Path $tempPem) { Remove-Item -Path $tempPem -Force -ErrorAction SilentlyContinue }
+                    if (Test-Path -Path $derPath) { Remove-Item -Path $derPath -Force -ErrorAction SilentlyContinue }
+                }
+            }
         }
     }
 }

--- a/Public/Get-CertificateData.ps1
+++ b/Public/Get-CertificateData.ps1
@@ -89,7 +89,7 @@ function Get-CertificateData {
                 $tempPem = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ('pssl-cert-{0}.pem' -f (New-Guid).ToString().Substring(0, 8))
                 $derPath = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ('pssl-cert-{0}.der' -f (New-Guid).ToString().Substring(0, 8))
                 try {
-                    [System.IO.File]::WriteAllText($tempPem, $block.Value)
+                    [System.IO.File]::WriteAllText($tempPem, $block.Value, [System.Text.Encoding]::ASCII)
                     [System.Void] (Invoke-OpenSsl -ArgumentList @('x509', '-in', $tempPem, '-outform', 'DER', '-out', $derPath))
                     [System.Security.Cryptography.X509Certificates.X509Certificate2]::new(
                         [System.IO.File]::ReadAllBytes($derPath))

--- a/Public/Get-CertificateData.ps1
+++ b/Public/Get-CertificateData.ps1
@@ -72,7 +72,7 @@ function Get-CertificateData {
 
         if ($blocks.Count -le 1) {
             # Single cert or DER format — original behavior preserved.
-            $derPath = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ('pssl-cert-{0}.der' -f [System.Guid]::NewGuid().Guid.Substring(0, 8))
+            $derPath = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ('pssl-cert-{0}.der' -f (New-Guid).ToString().Substring(0, 8))
             try {
                 [System.Void] (Invoke-OpenSsl -ArgumentList @('x509', '-in', $Path, '-outform', 'DER', '-out', $derPath))
                 [System.Security.Cryptography.X509Certificates.X509Certificate2]::new(
@@ -86,8 +86,8 @@ function Get-CertificateData {
             # PEM bundle — emit one X509Certificate2 per block to the pipeline.
             Write-Verbose -Message "Found $($blocks.Count) certificates in '$Path'"
             foreach ($block in $blocks) {
-                $tempPem = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ('pssl-cert-{0}.pem' -f [System.Guid]::NewGuid().Guid.Substring(0, 8))
-                $derPath = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ('pssl-cert-{0}.der' -f [System.Guid]::NewGuid().Guid.Substring(0, 8))
+                $tempPem = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ('pssl-cert-{0}.pem' -f (New-Guid).ToString().Substring(0, 8))
+                $derPath = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ('pssl-cert-{0}.der' -f (New-Guid).ToString().Substring(0, 8))
                 try {
                     [System.IO.File]::WriteAllText($tempPem, $block.Value)
                     [System.Void] (Invoke-OpenSsl -ArgumentList @('x509', '-in', $tempPem, '-outform', 'DER', '-out', $derPath))

--- a/Public/Get-CertificateData.ps1
+++ b/Public/Get-CertificateData.ps1
@@ -50,53 +50,55 @@ function Get-CertificateData {
     Param(
         [Parameter(Mandatory, ValueFromPipeline, HelpMessage = 'Path to x509 certificate file')]
         [ValidateScript({
-                if (-not (Test-Path -Path $_ -PathType Leaf)) { Write-Error -Message "File not found: $_" -ErrorAction Stop }
+                if (-not (Test-Path -Path $_ -PathType Leaf)) {
+                    Write-Error -Message ('File not found: {0}' -f $_) -ErrorAction Stop
+                }
                 $ext = [System.IO.Path]::GetExtension($_).ToLowerInvariant()
                 if ($ext -notin '.crt', '.cer', '.pem') {
-                    Write-Error -Message "Unsupported extension '$ext'. Expected .crt, .cer, or .pem." -ErrorAction Stop
+                    Write-Error -Message ('Unsupported extension [{0}]. Expected .crt, .cer, or .pem.' -f $ext) -ErrorAction Stop
                 }
                 $true
             })]
         [System.String] $Path
     )
     Begin {
-        Write-Verbose -Message "Starting $($MyInvocation.Mycommand)"
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
     }
     Process {
-        # Scan for PEM certificate blocks. This handles both single-cert files
-        # and bundles (e.g. fullchain.pem). DER files produce zero matches and
-        # fall through to the single-cert path unchanged.
+        # SCAN FOR PEM CERTIFICATE BLOCKS — HANDLES SINGLE-CERT FILES AND BUNDLES.
+        # ReadAllText IS USED OVER Get-Content -Raw BECAUSE THE LATTER RETURNS $null
+        # FOR EMPTY FILES, WHICH WOULD CAUSE Regex::Matches TO THROW.
         $pemPattern = '-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----'
         $blocks = [System.Text.RegularExpressions.Regex]::Matches(
             [System.IO.File]::ReadAllText($Path), $pemPattern)
 
         if ($blocks.Count -le 1) {
-            # Single cert or DER format — original behavior preserved.
+            # SINGLE CERT OR DER FORMAT — ORIGINAL BEHAVIOR PRESERVED
             $derPath = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ('pssl-cert-{0}.der' -f (New-Guid).ToString().Substring(0, 8))
             try {
                 [System.Void] (Invoke-OpenSsl -ArgumentList @('x509', '-in', $Path, '-outform', 'DER', '-out', $derPath))
                 [System.Security.Cryptography.X509Certificates.X509Certificate2]::new(
-                    [System.IO.File]::ReadAllBytes($derPath))
+                    (Get-Content -Path $derPath -AsByteStream -Raw))
             }
             finally {
-                if (Test-Path -Path $derPath) { Remove-Item -Path $derPath -Force -ErrorAction SilentlyContinue }
+                if (Test-Path -Path $derPath) { Remove-Item -Path $derPath -Force -ErrorAction Ignore }
             }
         }
         else {
-            # PEM bundle — emit one X509Certificate2 per block to the pipeline.
-            Write-Verbose -Message "Found $($blocks.Count) certificates in '$Path'"
+            # PEM BUNDLE — EMIT ONE X509Certificate2 PER BLOCK TO THE PIPELINE
+            Write-Verbose -Message ('Found [{0}] certificates in [{1}]' -f $blocks.Count, $Path)
             foreach ($block in $blocks) {
                 $tempPem = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ('pssl-cert-{0}.pem' -f (New-Guid).ToString().Substring(0, 8))
                 $derPath = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ('pssl-cert-{0}.der' -f (New-Guid).ToString().Substring(0, 8))
                 try {
-                    [System.IO.File]::WriteAllText($tempPem, $block.Value, [System.Text.Encoding]::ASCII)
+                    Set-Content -Path $tempPem -Value $block.Value -Encoding ASCII -NoNewline
                     [System.Void] (Invoke-OpenSsl -ArgumentList @('x509', '-in', $tempPem, '-outform', 'DER', '-out', $derPath))
                     [System.Security.Cryptography.X509Certificates.X509Certificate2]::new(
-                        [System.IO.File]::ReadAllBytes($derPath))
+                        (Get-Content -Path $derPath -AsByteStream -Raw))
                 }
                 finally {
-                    if (Test-Path -Path $tempPem) { Remove-Item -Path $tempPem -Force -ErrorAction SilentlyContinue }
-                    if (Test-Path -Path $derPath) { Remove-Item -Path $derPath -Force -ErrorAction SilentlyContinue }
+                    if (Test-Path -Path $tempPem) { Remove-Item -Path $tempPem -Force -ErrorAction Ignore }
+                    if (Test-Path -Path $derPath) { Remove-Item -Path $derPath -Force -ErrorAction Ignore }
                 }
             }
         }

--- a/Tests/Unit/Get-CertificateData.Tests.ps1
+++ b/Tests/Unit/Get-CertificateData.Tests.ps1
@@ -27,16 +27,16 @@ BeforeAll {
         "-----BEGIN CERTIFICATE-----`n$b64`n-----END CERTIFICATE-----"
     }
 
-    $cert1 = New-FixtureCert 'PSSL Unit Test'
-    $cert2 = New-FixtureCert 'PSSL Intermediate CA'
-    $cert3 = New-FixtureCert 'PSSL Root CA'
+    $script:cert1 = New-FixtureCert 'PSSL Unit Test'
+    $script:cert2 = New-FixtureCert 'PSSL Intermediate CA'
+    $script:cert3 = New-FixtureCert 'PSSL Root CA'
 
-    $script:fixtureDer         = $cert1.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert)
-    $script:fixtureDer2        = $cert2.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert)
-    $script:fixtureDer3        = $cert3.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert)
-    $script:fixtureThumbprint  = $cert1.Thumbprint
-    $script:fixtureThumbprint2 = $cert2.Thumbprint
-    $script:fixtureThumbprint3 = $cert3.Thumbprint
+    $script:fixtureDer         = $script:cert1.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert)
+    $script:fixtureDer2        = $script:cert2.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert)
+    $script:fixtureDer3        = $script:cert3.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert)
+    $script:fixtureThumbprint  = $script:cert1.Thumbprint
+    $script:fixtureThumbprint2 = $script:cert2.Thumbprint
+    $script:fixtureThumbprint3 = $script:cert3.Thumbprint
 
     # Three-cert PEM bundle (leaf + intermediate + root) used in bundle tests.
     $script:bundlePem = (ConvertTo-PemString $script:fixtureDer) + "`n" +
@@ -45,6 +45,12 @@ BeforeAll {
 
     # Ordered DER bytes for the bundle, used by the stateful mock below.
     $script:bundleDerBytes = @($script:fixtureDer, $script:fixtureDer2, $script:fixtureDer3)
+}
+
+AfterAll {
+    $script:cert1.Dispose()
+    $script:cert2.Dispose()
+    $script:cert3.Dispose()
 }
 
 Describe 'Get-CertificateData' {
@@ -189,6 +195,25 @@ Describe 'Get-CertificateData' {
             Get-CertificateData -Path $script:bundlePath | Out-Null
             $derAfter  = @(Get-ChildItem -Path ([System.IO.Path]::GetTempPath()) -Filter 'pssl-cert-*.der'  -ErrorAction SilentlyContinue)
             $pemAfter  = @(Get-ChildItem -Path ([System.IO.Path]::GetTempPath()) -Filter 'pssl-cert-*.pem'  -ErrorAction SilentlyContinue)
+            $derAfter.Count | Should -Be $derBefore.Count
+            $pemAfter.Count | Should -Be $pemBefore.Count
+        }
+
+        It 'Propagates a terminating error when openssl fails mid-bundle and still cleans up temp files' {
+            Mock -ModuleName PS.SSL Invoke-OpenSsl {
+                if ($script:mockCallIndex -eq 1) { throw 'openssl error: invalid certificate' }
+                $outIndex = [System.Array]::IndexOf($ArgumentList, '-out')
+                if ($outIndex -ge 0 -and $outIndex + 1 -lt $ArgumentList.Length) {
+                    [System.IO.File]::WriteAllBytes($ArgumentList[$outIndex + 1], $script:bundleDerBytes[$script:mockCallIndex])
+                }
+                $script:mockCallIndex++
+                [PSCustomObject] @{ ExitCode = 0; StdOut = ''; StdErr = '' }
+            }
+            $derBefore = @(Get-ChildItem -Path ([System.IO.Path]::GetTempPath()) -Filter 'pssl-cert-*.der' -ErrorAction SilentlyContinue)
+            $pemBefore = @(Get-ChildItem -Path ([System.IO.Path]::GetTempPath()) -Filter 'pssl-cert-*.pem' -ErrorAction SilentlyContinue)
+            { Get-CertificateData -Path $script:bundlePath } | Should -Throw
+            $derAfter = @(Get-ChildItem -Path ([System.IO.Path]::GetTempPath()) -Filter 'pssl-cert-*.der' -ErrorAction SilentlyContinue)
+            $pemAfter = @(Get-ChildItem -Path ([System.IO.Path]::GetTempPath()) -Filter 'pssl-cert-*.pem' -ErrorAction SilentlyContinue)
             $derAfter.Count | Should -Be $derBefore.Count
             $pemAfter.Count | Should -Be $pemBefore.Count
         }

--- a/Tests/Unit/Get-CertificateData.Tests.ps1
+++ b/Tests/Unit/Get-CertificateData.Tests.ps1
@@ -8,25 +8,43 @@ BeforeAll {
     Get-Module -Name 'PS.SSL' -All | Remove-Module -Force -ErrorAction SilentlyContinue
     Import-Module -Name $manifestPath -Force
 
-    # A minimal valid DER blob that .NET X509Certificate2::new() will accept
-    # would still need to be a real cert. To avoid bundling a binary fixture,
-    # we generate a self-signed cert in-memory with .NET, export to DER, and
-    # have the mocked Invoke-OpenSsl write those bytes to the temp DER path.
-    $rsa = [System.Security.Cryptography.RSA]::Create(2048)
-    try {
-        $req = [System.Security.Cryptography.X509Certificates.CertificateRequest]::new(
-            'CN=PSSL Unit Test',
-            $rsa,
-            [System.Security.Cryptography.HashAlgorithmName]::SHA256,
-            [System.Security.Cryptography.RSASignaturePadding]::Pkcs1
-        )
-        $cert = $req.CreateSelfSigned([datetimeoffset]::UtcNow.AddDays(-1), [datetimeoffset]::UtcNow.AddDays(30))
-        $script:fixtureDer  = $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert)
-        $script:fixtureThumbprint = $cert.Thumbprint
+    # Generate in-memory self-signed certs for fixture use. We create three so
+    # that multi-cert bundle tests can verify count and individual thumbprints.
+    function New-FixtureCert ([string] $Subject) {
+        $rsa = [System.Security.Cryptography.RSA]::Create(2048)
+        try {
+            $req = [System.Security.Cryptography.X509Certificates.CertificateRequest]::new(
+                "CN=$Subject", $rsa,
+                [System.Security.Cryptography.HashAlgorithmName]::SHA256,
+                [System.Security.Cryptography.RSASignaturePadding]::Pkcs1)
+            $req.CreateSelfSigned([datetimeoffset]::UtcNow.AddDays(-1), [datetimeoffset]::UtcNow.AddDays(30))
+        }
+        finally { $rsa.Dispose() }
     }
-    finally {
-        $rsa.Dispose()
+
+    function ConvertTo-PemString ([byte[]] $der) {
+        $b64 = [System.Convert]::ToBase64String($der, [System.Base64FormattingOptions]::InsertLineBreaks)
+        "-----BEGIN CERTIFICATE-----`n$b64`n-----END CERTIFICATE-----"
     }
+
+    $cert1 = New-FixtureCert 'PSSL Unit Test'
+    $cert2 = New-FixtureCert 'PSSL Intermediate CA'
+    $cert3 = New-FixtureCert 'PSSL Root CA'
+
+    $script:fixtureDer         = $cert1.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert)
+    $script:fixtureDer2        = $cert2.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert)
+    $script:fixtureDer3        = $cert3.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert)
+    $script:fixtureThumbprint  = $cert1.Thumbprint
+    $script:fixtureThumbprint2 = $cert2.Thumbprint
+    $script:fixtureThumbprint3 = $cert3.Thumbprint
+
+    # Three-cert PEM bundle (leaf + intermediate + root) used in bundle tests.
+    $script:bundlePem = (ConvertTo-PemString $script:fixtureDer) + "`n" +
+                        (ConvertTo-PemString $script:fixtureDer2) + "`n" +
+                        (ConvertTo-PemString $script:fixtureDer3)
+
+    # Ordered DER bytes for the bundle, used by the stateful mock below.
+    $script:bundleDerBytes = @($script:fixtureDer, $script:fixtureDer2, $script:fixtureDer3)
 }
 
 Describe 'Get-CertificateData' {
@@ -86,7 +104,7 @@ Describe 'Get-CertificateData' {
             }
         }
 
-        It 'Passes the input file path to openssl via -in' {
+        It 'Passes the input file path to openssl via -in for a single-cert file' {
             Get-CertificateData -Path $script:certPath | Out-Null
             Should -Invoke -ModuleName PS.SSL -CommandName 'Invoke-OpenSsl' -Times 1 -Exactly -ParameterFilter {
                 $inIndex = [System.Array]::IndexOf($ArgumentList, '-in')
@@ -95,7 +113,7 @@ Describe 'Get-CertificateData' {
         }
     }
 
-    Context 'Return type' {
+    Context 'Return type — single certificate' {
 
         BeforeEach {
             $script:certPath = Join-Path $TestDrive 'cert.pem'
@@ -118,6 +136,61 @@ Describe 'Get-CertificateData' {
             Get-CertificateData -Path $script:certPath | Out-Null
             $tempAfter = Get-ChildItem -Path ([System.IO.Path]::GetTempPath()) -Filter 'pssl-cert-*.der' -ErrorAction SilentlyContinue
             $tempAfter.Count | Should -Be $tempBefore.Count
+        }
+    }
+
+    Context 'Multi-certificate PEM bundle' {
+
+        BeforeEach {
+            $script:bundlePath = Join-Path $TestDrive 'fullchain.pem'
+            Set-Content -Path $script:bundlePath -Value $script:bundlePem
+
+            # Stateful mock: each call writes the next cert's DER bytes so the
+            # returned objects reflect the correct per-block fixture thumbprints.
+            $script:mockCallIndex = 0
+            Mock -ModuleName PS.SSL Invoke-OpenSsl {
+                $outIndex = [System.Array]::IndexOf($ArgumentList, '-out')
+                if ($outIndex -ge 0 -and $outIndex + 1 -lt $ArgumentList.Length) {
+                    $outPath = $ArgumentList[$outIndex + 1]
+                    [System.IO.File]::WriteAllBytes($outPath, $script:bundleDerBytes[$script:mockCallIndex])
+                }
+                $script:mockCallIndex++
+                [PSCustomObject] @{ ExitCode = 0; StdOut = ''; StdErr = '' }
+            }
+        }
+
+        It 'Returns 3 X509Certificate2 objects for a 3-cert bundle' {
+            $results = @(Get-CertificateData -Path $script:bundlePath)
+            $results.Count | Should -Be 3
+        }
+
+        It 'Each returned object is an X509Certificate2 instance' {
+            $results = @(Get-CertificateData -Path $script:bundlePath)
+            foreach ($r in $results) {
+                $r | Should -BeOfType ([System.Security.Cryptography.X509Certificates.X509Certificate2])
+            }
+        }
+
+        It 'Invokes openssl once per certificate block' {
+            Get-CertificateData -Path $script:bundlePath | Out-Null
+            Should -Invoke -ModuleName PS.SSL -CommandName 'Invoke-OpenSsl' -Times 3 -Exactly
+        }
+
+        It 'Returns certificates in bundle order' {
+            $results = @(Get-CertificateData -Path $script:bundlePath)
+            $results[0].Thumbprint | Should -Be $script:fixtureThumbprint
+            $results[1].Thumbprint | Should -Be $script:fixtureThumbprint2
+            $results[2].Thumbprint | Should -Be $script:fixtureThumbprint3
+        }
+
+        It 'Cleans up all temporary PEM and DER files after processing the bundle' {
+            $derBefore = @(Get-ChildItem -Path ([System.IO.Path]::GetTempPath()) -Filter 'pssl-cert-*.der'  -ErrorAction SilentlyContinue)
+            $pemBefore = @(Get-ChildItem -Path ([System.IO.Path]::GetTempPath()) -Filter 'pssl-cert-*.pem'  -ErrorAction SilentlyContinue)
+            Get-CertificateData -Path $script:bundlePath | Out-Null
+            $derAfter  = @(Get-ChildItem -Path ([System.IO.Path]::GetTempPath()) -Filter 'pssl-cert-*.der'  -ErrorAction SilentlyContinue)
+            $pemAfter  = @(Get-ChildItem -Path ([System.IO.Path]::GetTempPath()) -Filter 'pssl-cert-*.pem'  -ErrorAction SilentlyContinue)
+            $derAfter.Count | Should -Be $derBefore.Count
+            $pemAfter.Count | Should -Be $pemBefore.Count
         }
     }
 }

--- a/Tests/Unit/Get-CertificateData.Tests.ps1
+++ b/Tests/Unit/Get-CertificateData.Tests.ps1
@@ -1,3 +1,15 @@
+BeforeDiscovery {
+    $manifestPath = if ($env:BHPSModuleManifest) {
+        $env:BHPSModuleManifest
+    }
+    else {
+        Join-Path -Path $PSScriptRoot -ChildPath '..\..\PS.SSL.psd1' | Resolve-Path | Select-Object -ExpandProperty Path
+    }
+    if (-not (Get-Module -Name 'PS.SSL')) {
+        Import-Module -Name $manifestPath -ErrorAction Stop -Force
+    }
+}
+
 BeforeAll {
     $manifestPath = if ($env:BHPSModuleManifest) {
         $env:BHPSModuleManifest
@@ -8,13 +20,12 @@ BeforeAll {
     Get-Module -Name 'PS.SSL' -All | Remove-Module -Force -ErrorAction SilentlyContinue
     Import-Module -Name $manifestPath -Force
 
-    # Generate in-memory self-signed certs for fixture use. We create three so
-    # that multi-cert bundle tests can verify count and individual thumbprints.
-    function New-FixtureCert ([string] $Subject) {
+    # HELPER: CREATE AN IN-MEMORY SELF-SIGNED CERT FOR FIXTURE USE
+    function New-FixtureCert ([System.String] $Subject) {
         $rsa = [System.Security.Cryptography.RSA]::Create(2048)
         try {
             $req = [System.Security.Cryptography.X509Certificates.CertificateRequest]::new(
-                "CN=$Subject", $rsa,
+                ('CN={0}' -f $Subject), $rsa,
                 [System.Security.Cryptography.HashAlgorithmName]::SHA256,
                 [System.Security.Cryptography.RSASignaturePadding]::Pkcs1)
             $req.CreateSelfSigned([datetimeoffset]::UtcNow.AddDays(-1), [datetimeoffset]::UtcNow.AddDays(30))
@@ -22,14 +33,16 @@ BeforeAll {
         finally { $rsa.Dispose() }
     }
 
-    function ConvertTo-PemString ([byte[]] $der) {
-        $b64 = [System.Convert]::ToBase64String($der, [System.Base64FormattingOptions]::InsertLineBreaks)
-        "-----BEGIN CERTIFICATE-----`n$b64`n-----END CERTIFICATE-----"
+    # HELPER: CONVERT DER BYTES TO A PEM-ENCODED STRING
+    function ConvertTo-PemString ([System.Byte[]] $Der) {
+        $b64 = [System.Convert]::ToBase64String($Der, [System.Base64FormattingOptions]::InsertLineBreaks)
+        '-----BEGIN CERTIFICATE-----{0}{1}{0}-----END CERTIFICATE-----' -f "`n", $b64
     }
 
-    $script:cert1 = New-FixtureCert 'PSSL Unit Test'
-    $script:cert2 = New-FixtureCert 'PSSL Intermediate CA'
-    $script:cert3 = New-FixtureCert 'PSSL Root CA'
+    # GENERATE THREE CERTS FOR SINGLE-CERT AND BUNDLE FIXTURE SCENARIOS
+    $script:cert1 = New-FixtureCert -Subject 'PSSL Unit Test'
+    $script:cert2 = New-FixtureCert -Subject 'PSSL Intermediate CA'
+    $script:cert3 = New-FixtureCert -Subject 'PSSL Root CA'
 
     $script:fixtureDer         = $script:cert1.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert)
     $script:fixtureDer2        = $script:cert2.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert)
@@ -38,12 +51,14 @@ BeforeAll {
     $script:fixtureThumbprint2 = $script:cert2.Thumbprint
     $script:fixtureThumbprint3 = $script:cert3.Thumbprint
 
-    # Three-cert PEM bundle (leaf + intermediate + root) used in bundle tests.
-    $script:bundlePem = (ConvertTo-PemString $script:fixtureDer) + "`n" +
-                        (ConvertTo-PemString $script:fixtureDer2) + "`n" +
-                        (ConvertTo-PemString $script:fixtureDer3)
+    # THREE-CERT PEM BUNDLE (LEAF + INTERMEDIATE + ROOT) USED IN BUNDLE TESTS
+    $script:bundlePem = @(
+        ConvertTo-PemString -Der $script:fixtureDer
+        ConvertTo-PemString -Der $script:fixtureDer2
+        ConvertTo-PemString -Der $script:fixtureDer3
+    ) -join "`n"
 
-    # Ordered DER bytes for the bundle, used by the stateful mock below.
+    # ORDERED DER BYTES FOR THE BUNDLE — CONSUMED BY THE STATEFUL MOCK
     $script:bundleDerBytes = @($script:fixtureDer, $script:fixtureDer2, $script:fixtureDer3)
 }
 
@@ -53,14 +68,12 @@ AfterAll {
     $script:cert3.Dispose()
 }
 
-Describe 'Get-CertificateData' {
+Describe -Name 'Get-CertificateData' -Fixture {
 
     BeforeEach {
-        # Mock the module-private openssl boundary. Get-CertificateData
-        # writes its DER output via `openssl x509 -outform DER -out <path>`
-        # then reads that file back. The mock locates the `-out` argument
-        # and writes the in-memory fixture DER bytes to that path.
-        Mock -ModuleName PS.SSL Invoke-OpenSsl {
+        # MOCK THE MODULE-PRIVATE OPENSSL BOUNDARY — LOCATES THE -OUT ARGUMENT
+        # AND WRITES FIXTURE DER BYTES TO THAT PATH INSTEAD OF INVOKING OPENSSL
+        Mock -ModuleName PS.SSL -CommandName Invoke-OpenSsl -MockWith {
             $outIndex = [System.Array]::IndexOf($ArgumentList, '-out')
             if ($outIndex -ge 0 -and $outIndex + 1 -lt $ArgumentList.Length) {
                 $outPath = $ArgumentList[$outIndex + 1]
@@ -70,47 +83,47 @@ Describe 'Get-CertificateData' {
         }
     }
 
-    Context 'Parameter validation' {
+    Context -Name 'Parameter validation' -Fixture {
 
-        It 'Rejects a path that does not exist' {
-            $missing = Join-Path $TestDrive 'does-not-exist.pem'
+        It -Name 'rejects a path that does not exist' -Test {
+            $missing = Join-Path -Path $TestDrive -ChildPath 'does-not-exist.pem'
             { Get-CertificateData -Path $missing } | Should -Throw
         }
 
-        It 'Rejects a path with an unsupported extension' {
-            $bad = Join-Path $TestDrive 'cert.txt'
+        It -Name 'rejects a path with an unsupported extension' -Test {
+            $bad = Join-Path -Path $TestDrive -ChildPath 'cert.txt'
             Set-Content -Path $bad -Value 'placeholder'
             { Get-CertificateData -Path $bad } | Should -Throw
         }
 
-        It 'Accepts .pem, .crt, and .cer extensions' {
+        It -Name 'accepts .pem, .crt, and .cer extensions' -Test {
             foreach ($ext in '.pem', '.crt', '.cer') {
-                $path = Join-Path $TestDrive ('cert{0}' -f $ext)
+                $path = Join-Path -Path $TestDrive -ChildPath ('cert{0}' -f $ext)
                 Set-Content -Path $path -Value 'placeholder'
                 { Get-CertificateData -Path $path } | Should -Not -Throw
             }
         }
     }
 
-    Context 'OpenSSL invocation' {
+    Context -Name 'OpenSSL invocation' -Fixture {
 
         BeforeEach {
-            $script:certPath = Join-Path $TestDrive 'cert.pem'
+            $script:certPath = Join-Path -Path $TestDrive -ChildPath 'cert.pem'
             Set-Content -Path $script:certPath -Value 'placeholder'
         }
 
-        It 'Invokes openssl x509 with -outform DER' {
+        It -Name 'invokes openssl x509 with -outform DER' -Test {
             Get-CertificateData -Path $script:certPath | Out-Null
             Should -Invoke -ModuleName PS.SSL -CommandName 'Invoke-OpenSsl' -Times 1 -Exactly -ParameterFilter {
-                ($ArgumentList -contains 'x509')    -and
-                ($ArgumentList -contains '-in')     -and
-                ($ArgumentList -contains '-outform')-and
-                ($ArgumentList -contains 'DER')     -and
+                ($ArgumentList -contains 'x509')     -and
+                ($ArgumentList -contains '-in')      -and
+                ($ArgumentList -contains '-outform') -and
+                ($ArgumentList -contains 'DER')      -and
                 ($ArgumentList -contains '-out')
             }
         }
 
-        It 'Passes the input file path to openssl via -in for a single-cert file' {
+        It -Name 'passes the input file path to openssl via -in for a single-cert file' -Test {
             Get-CertificateData -Path $script:certPath | Out-Null
             Should -Invoke -ModuleName PS.SSL -CommandName 'Invoke-OpenSsl' -Times 1 -Exactly -ParameterFilter {
                 $inIndex = [System.Array]::IndexOf($ArgumentList, '-in')
@@ -119,25 +132,25 @@ Describe 'Get-CertificateData' {
         }
     }
 
-    Context 'Return type — single certificate' {
+    Context -Name 'Return type — single certificate' -Fixture {
 
         BeforeEach {
-            $script:certPath = Join-Path $TestDrive 'cert.pem'
+            $script:certPath = Join-Path -Path $TestDrive -ChildPath 'cert.pem'
             Set-Content -Path $script:certPath -Value 'placeholder'
         }
 
-        It 'Returns an X509Certificate2 instance' {
+        It -Name 'returns an X509Certificate2 instance' -Test {
             $result = Get-CertificateData -Path $script:certPath
             $result | Should -BeOfType ([System.Security.Cryptography.X509Certificates.X509Certificate2])
         }
 
-        It 'Returns the certificate constructed from openssl-normalized DER bytes' {
+        It -Name 'returns the certificate constructed from openssl-normalized DER bytes' -Test {
             $result = Get-CertificateData -Path $script:certPath
             $result.Thumbprint | Should -Be $script:fixtureThumbprint
             $result.Subject    | Should -Match 'PSSL Unit Test'
         }
 
-        It 'Cleans up the temporary DER file after constructing the certificate' {
+        It -Name 'cleans up the temporary DER file after constructing the certificate' -Test {
             $tempBefore = Get-ChildItem -Path ([System.IO.Path]::GetTempPath()) -Filter 'pssl-cert-*.der' -ErrorAction SilentlyContinue
             Get-CertificateData -Path $script:certPath | Out-Null
             $tempAfter = Get-ChildItem -Path ([System.IO.Path]::GetTempPath()) -Filter 'pssl-cert-*.der' -ErrorAction SilentlyContinue
@@ -145,16 +158,16 @@ Describe 'Get-CertificateData' {
         }
     }
 
-    Context 'Multi-certificate PEM bundle' {
+    Context -Name 'Multi-certificate PEM bundle' -Fixture {
 
         BeforeEach {
-            $script:bundlePath = Join-Path $TestDrive 'fullchain.pem'
+            $script:bundlePath = Join-Path -Path $TestDrive -ChildPath 'fullchain.pem'
             Set-Content -Path $script:bundlePath -Value $script:bundlePem
 
-            # Stateful mock: each call writes the next cert's DER bytes so the
-            # returned objects reflect the correct per-block fixture thumbprints.
+            # STATEFUL MOCK: EACH CALL WRITES THE NEXT CERT'S DER BYTES SO THE
+            # RETURNED OBJECTS REFLECT THE CORRECT PER-BLOCK FIXTURE THUMBPRINTS
             $script:mockCallIndex = 0
-            Mock -ModuleName PS.SSL Invoke-OpenSsl {
+            Mock -ModuleName PS.SSL -CommandName Invoke-OpenSsl -MockWith {
                 $outIndex = [System.Array]::IndexOf($ArgumentList, '-out')
                 if ($outIndex -ge 0 -and $outIndex + 1 -lt $ArgumentList.Length) {
                     $outPath = $ArgumentList[$outIndex + 1]
@@ -165,43 +178,43 @@ Describe 'Get-CertificateData' {
             }
         }
 
-        It 'Returns 3 X509Certificate2 objects for a 3-cert bundle' {
+        It -Name 'returns 3 X509Certificate2 objects for a 3-cert bundle' -Test {
             $results = @(Get-CertificateData -Path $script:bundlePath)
             $results.Count | Should -Be 3
         }
 
-        It 'Each returned object is an X509Certificate2 instance' {
+        It -Name 'each returned object is an X509Certificate2 instance' -Test {
             $results = @(Get-CertificateData -Path $script:bundlePath)
             foreach ($r in $results) {
                 $r | Should -BeOfType ([System.Security.Cryptography.X509Certificates.X509Certificate2])
             }
         }
 
-        It 'Invokes openssl once per certificate block' {
+        It -Name 'invokes openssl once per certificate block' -Test {
             Get-CertificateData -Path $script:bundlePath | Out-Null
             Should -Invoke -ModuleName PS.SSL -CommandName 'Invoke-OpenSsl' -Times 3 -Exactly
         }
 
-        It 'Returns certificates in bundle order' {
+        It -Name 'returns certificates in bundle order' -Test {
             $results = @(Get-CertificateData -Path $script:bundlePath)
             $results[0].Thumbprint | Should -Be $script:fixtureThumbprint
             $results[1].Thumbprint | Should -Be $script:fixtureThumbprint2
             $results[2].Thumbprint | Should -Be $script:fixtureThumbprint3
         }
 
-        It 'Cleans up all temporary PEM and DER files after processing the bundle' {
-            $derBefore = @(Get-ChildItem -Path ([System.IO.Path]::GetTempPath()) -Filter 'pssl-cert-*.der'  -ErrorAction SilentlyContinue)
-            $pemBefore = @(Get-ChildItem -Path ([System.IO.Path]::GetTempPath()) -Filter 'pssl-cert-*.pem'  -ErrorAction SilentlyContinue)
+        It -Name 'cleans up all temporary PEM and DER files after processing the bundle' -Test {
+            $derBefore = @(Get-ChildItem -Path ([System.IO.Path]::GetTempPath()) -Filter 'pssl-cert-*.der' -ErrorAction SilentlyContinue)
+            $pemBefore = @(Get-ChildItem -Path ([System.IO.Path]::GetTempPath()) -Filter 'pssl-cert-*.pem' -ErrorAction SilentlyContinue)
             Get-CertificateData -Path $script:bundlePath | Out-Null
-            $derAfter  = @(Get-ChildItem -Path ([System.IO.Path]::GetTempPath()) -Filter 'pssl-cert-*.der'  -ErrorAction SilentlyContinue)
-            $pemAfter  = @(Get-ChildItem -Path ([System.IO.Path]::GetTempPath()) -Filter 'pssl-cert-*.pem'  -ErrorAction SilentlyContinue)
+            $derAfter  = @(Get-ChildItem -Path ([System.IO.Path]::GetTempPath()) -Filter 'pssl-cert-*.der' -ErrorAction SilentlyContinue)
+            $pemAfter  = @(Get-ChildItem -Path ([System.IO.Path]::GetTempPath()) -Filter 'pssl-cert-*.pem' -ErrorAction SilentlyContinue)
             $derAfter.Count | Should -Be $derBefore.Count
             $pemAfter.Count | Should -Be $pemBefore.Count
         }
 
-        It 'Propagates a terminating error when openssl fails mid-bundle and still cleans up temp files' {
-            Mock -ModuleName PS.SSL Invoke-OpenSsl {
-                if ($script:mockCallIndex -eq 1) { throw 'openssl error: invalid certificate' }
+        It -Name 'propagates a terminating error when openssl fails mid-bundle and still cleans up temp files' -Test {
+            Mock -ModuleName PS.SSL -CommandName Invoke-OpenSsl -MockWith {
+                if ($script:mockCallIndex -eq 1) { Write-Error -Message 'openssl error: invalid certificate' -ErrorAction Stop }
                 $outIndex = [System.Array]::IndexOf($ArgumentList, '-out')
                 if ($outIndex -ge 0 -and $outIndex + 1 -lt $ArgumentList.Length) {
                     [System.IO.File]::WriteAllBytes($ArgumentList[$outIndex + 1], $script:bundleDerBytes[$script:mockCallIndex])


### PR DESCRIPTION
## Summary

Closes #39

- `Get-CertificateData` now emits one `X509Certificate2` per `-----BEGIN CERTIFICATE-----` block, so bundles like `fullchain.pem` (leaf + intermediates + root) return all certs to the pipeline
- Single-cert files and DER-encoded files (`.crt`, `.cer`) are unchanged — still return exactly one object
- Each block is extracted to a temp PEM, normalized to DER via openssl, then constructed into `X509Certificate2`; both temp files are cleaned up in a `finally` block
- Replaced `[System.Guid]::NewGuid()` with the native `New-Guid` cmdlet; also fixed the latent `.Guid` property access (not a real property on `System.Guid`) to use `.ToString()` instead

## Approach

Implements **Option A** from the issue (always enumerate), which aligns with standard PowerShell pipeline idioms. Callers can wrap in `@(...)` if they need array semantics when the file may contain only one certificate.

## Test plan

- [ ] `Get-CertificateData` returns 1 object for a single-cert PEM (existing behavior)
- [ ] `Get-CertificateData` returns 3 objects for a 3-cert bundle, in bundle order
- [ ] Each returned object is an `X509Certificate2` instance
- [ ] `Invoke-OpenSsl` is called once per cert block (3× for a 3-cert bundle)
- [ ] All temp `.pem` and `.der` files are cleaned up after processing
- [ ] Run full unit suite: `Invoke-Pester Tests/Unit/Get-CertificateData.Tests.ps1`

https://claude.ai/code/session_01ALg38UoBirqE1yX1pY5e4b