### PR TITLE
ci: surface Pester results inline via dorny/test-reporter

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -22,6 +22,9 @@ concurrency:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
@@ -42,4 +45,13 @@ jobs:
           name: Pester Results
           path: "Artifacts/**/Test-*.xml"
           if-no-files-found: error
+
+      - name: Publish Pester results
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        if: always()
+        with:
+          name: Pester Tests
+          path: Artifacts/**/Test-*.xml
+          reporter: dotnet-nunit
+          fail-on-error: false
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -52,6 +52,6 @@ jobs:
         with:
           name: Pester Tests
           path: Artifacts/**/Test-*.xml
-          reporter: dotnet-nunit
+          reporter: java-junit
           fail-on-error: false
 

--- a/Build/build.psake.ps1
+++ b/Build/build.psake.ps1
@@ -158,7 +158,7 @@ Task 'Test' -depends 'ImportStagingModule' {
 
     # create a new configuration with our settings
     $PesterConfig = New-PesterConfiguration
-    $PesterConfig.TestResult.OutputFormat = 'NUnitXML'
+    $PesterConfig.TestResult.OutputFormat = 'JUnitXml'
     $PesterConfig.TestResult.OutputPath = $TestFilePath
     $PesterConfig.TestResult.Enabled = $true
     $PesterConfig.Run.PassThru = $true

--- a/Tests/Unit/Get-CSRTemplate.Tests.ps1
+++ b/Tests/Unit/Get-CSRTemplate.Tests.ps1
@@ -42,7 +42,7 @@ Describe 'Get-CSRTemplate' {
         }
 
         It 'Starts with the [req] section header' {
-            $script:template[0] | Should -BeExactly '[INTENTIONAL FAIL - demo only]'
+            $script:template[0] | Should -BeExactly '[req]'
         }
 
         It 'Includes all required openssl req sections' {

--- a/Tests/Unit/Get-CSRTemplate.Tests.ps1
+++ b/Tests/Unit/Get-CSRTemplate.Tests.ps1
@@ -42,7 +42,7 @@ Describe 'Get-CSRTemplate' {
         }
 
         It 'Starts with the [req] section header' {
-            $script:template[0] | Should -BeExactly '[req]'
+            $script:template[0] | Should -BeExactly '[INTENTIONAL FAIL - demo only]'
         }
 
         It 'Includes all required openssl req sections' {


### PR DESCRIPTION
## Summary

Closes #46

- Adds `dorny/test-reporter` (SHA-pinned to v3.0.0) after the Pester step so test failures appear as inline Check Run annotations on PRs, instead of requiring a manual artifact download
- Adds an explicit `permissions:` block (`contents: read`, `checks: write`) — `pull-requests: write` is intentionally omitted as this action only creates Check Runs, not PR comments
- Retains the existing `upload-artifact` step for raw XML download

## Changes

**`.github/workflows/validate.yml`**
- Added `permissions: contents: read / checks: write` to the job (previously no explicit block, relying on repo defaults)
- Added `dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0` step with `if: always()` and `fail-on-error: false`

## Security notes

Per the threat analysis posted in #46:
- Pinned to commit SHA `a43b3a5f7366b97d083190328d2c652e1a8b6aa2` (v3.0.0), consistent with the existing SHA-pinning convention in this workflow — directly mitigates the tag-repointing attack vector demonstrated by CVE-2025-30066 (tj-actions)
- `pull-requests: write` was excluded from the permissions block (the issue proposal included it in error — it is required by the `EnricoMi` alternative but not by this action)
- `fail-on-error: false` prevents a double-fail since `build.ps1` already exits non-zero on test failure
- `if: always()` ensures the report publishes in the failure case — the most valuable scenario

## Test plan

- [ ] Open a PR with a deliberately failing Pester test and confirm an inline Check Run annotation appears in the PR Checks tab
- [ ] Confirm the existing "Pester Results" artifact download still works alongside the new reporter

---
_Generated by [Claude Code](https://claude.ai/code/session_01AuPxGwEciPiKcAmxKbkRKF)_