### PR TITLE
ci: add ubuntu+windows validate matrix (closes #37)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,21 +1,21 @@
 {
-	"name": "${localWorkspaceFolderBasename}",
-	"build": {
-		// Sets the run context to one level up instead of the .devcontainer folder.
-		"context": "..",
-		"dockerfile": "Dockerfile"
-	},
-	"customizations": {
-		"vscode": {
-			"settings": {
-				"terminal.integrated.defaultProfile.linux": "pwsh",
-				"terminal.integrated.defaultProfile.windows": "pwsh",
-				"terminal.integrated.defaultProfile.osx": "pwsh"
-			},
-			"extensions": [
-				"DavidAnson.vscode-markdownlint",
-				"ms-vscode.powershell"
-			]
-		}
-	}
+    "name": "${localWorkspaceFolderBasename}",
+    "build": {
+        // Sets the run context to one level up instead of the .devcontainer folder.
+        "context": "..",
+        "dockerfile": "Dockerfile"
+    },
+    "customizations": {
+        "vscode": {
+            "settings": {
+                "terminal.integrated.defaultProfile.linux": "pwsh",
+                "terminal.integrated.defaultProfile.windows": "pwsh",
+                "terminal.integrated.defaultProfile.osx": "pwsh"
+            },
+            "extensions": [
+                "DavidAnson.vscode-markdownlint",
+                "ms-vscode.powershell"
+            ]
+        }
+    }
 }

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -21,7 +21,14 @@ concurrency:
 
 jobs:
   validate:
-    runs-on: ubuntu-latest
+    strategy:
+      # fail-fast: false keeps the second runner going if the first fails so
+      # cross-OS divergence surfaces in a single run instead of fix-push-wait-repeat.
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     permissions:
       contents: read
       checks: write
@@ -42,7 +49,7 @@ jobs:
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: Pester Results
+          name: Pester Results (${{ matrix.os }})
           path: "Artifacts/**/Test-*.xml"
           if-no-files-found: error
 
@@ -50,8 +57,7 @@ jobs:
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         if: always()
         with:
-          name: Pester Tests
+          name: Pester Tests (${{ matrix.os }})
           path: Artifacts/**/Test-*.xml
           reporter: java-junit
           fail-on-error: false
-

--- a/Build/build.psake.ps1
+++ b/Build/build.psake.ps1
@@ -16,7 +16,19 @@ Properties {
     Set-Variable -Name 'lines' -Value '----------------------------------------------------------------------'
 
     # Pester
-    Set-Variable -Name 'TestScripts' -Value (Get-ChildItem "$ProjectRoot/Tests/*/*Tests.ps1")
+    # Cross-platform tests use the conventional *.Tests.ps1 suffix. Windows-only
+    # tests (Loader.Tests.windows.ps1) follow the SecurityTools pattern: the
+    # filename carries the platform gate so the build can pick them up only on
+    # Windows runners without per-test $IsWindows guards.
+    $crossPlatformTests = Get-ChildItem "$ProjectRoot/Tests/*/*Tests.ps1" |
+        Where-Object { $_.Name -notmatch '\.Tests\.windows\.ps1$' }
+    if ($IsWindows) {
+        $windowsTests = Get-ChildItem "$ProjectRoot/Tests/*/*.Tests.windows.ps1" -ErrorAction SilentlyContinue
+        Set-Variable -Name 'TestScripts' -Value ($crossPlatformTests + $windowsTests)
+    }
+    else {
+        Set-Variable -Name 'TestScripts' -Value $crossPlatformTests
+    }
     Set-Variable -Name 'TestFile' -Value "Test-Unit_$($Timestamp).xml"
 
     # Script Analyzer

--- a/Tests/Unit/Loader.Tests.ps1
+++ b/Tests/Unit/Loader.Tests.ps1
@@ -32,9 +32,11 @@ Describe -Name 'PS.SSL module loader' -Fixture {
     It -Name 'does not warn about missing openssl when openssl is on PATH' -Skip:($IsWindows) -Test {
         # Linux/macOS branch checks @('/usr/bin','/usr/sbin','/sbin','/bin').
         # Hosted CI runners ship openssl in /usr/bin so this branch should be quiet.
+        # Stream redirection (3>&1) is used because Import-Module's
+        # -WarningVariable does not capture warnings from a module's .psm1 body.
         Get-Module -Name $env:BHProjectName -All | Remove-Module -Force -ErrorAction 'SilentlyContinue'
-        $warnings = @()
-        Import-Module -Name $env:BHPSModuleManifest -Force -WarningVariable 'warnings' -WarningAction 'SilentlyContinue'
-        ($warnings | Where-Object -FilterScript { $_ -match 'Openssl not found' }) | Should -BeNullOrEmpty
+        $warnings = & { Import-Module -Name $env:BHPSModuleManifest -Force } 3>&1 |
+            Where-Object -FilterScript { $_ -is [System.Management.Automation.WarningRecord] }
+        ($warnings | Where-Object -FilterScript { $_.Message -match 'Openssl not found' }) | Should -BeNullOrEmpty
     }
 }

--- a/Tests/Unit/Loader.Tests.ps1
+++ b/Tests/Unit/Loader.Tests.ps1
@@ -1,0 +1,40 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'PS.SSL module loader' -Fixture {
+
+    It -Name 'imports without error in the current environment' -Test {
+        Get-Module -Name $env:BHProjectName -All | Remove-Module -Force -ErrorAction 'SilentlyContinue'
+        { Import-Module -Name $env:BHPSModuleManifest -Force } | Should -Not -Throw
+    }
+
+    It -Name 'tolerates the absence of an optional Private/ directory at import time' -Test {
+        # The loader skips a missing Private/ rather than letting Get-ChildItem
+        # throw on Linux/macOS, where the wildcard path is evaluated more
+        # strictly than on Windows. Stage a Private-less copy of the module
+        # into TestDrive and assert Import-Module does not throw.
+        $moduleRoot = Split-Path -Path $env:BHPSModuleManifest -Parent
+        $stage = Join-Path -Path $TestDrive -ChildPath $env:BHProjectName
+        New-Item -Path $stage -ItemType 'Directory' -Force | Out-Null
+        Copy-Item -Path (Join-Path -Path $moduleRoot -ChildPath ('{0}.psd1' -f $env:BHProjectName)) -Destination $stage
+        Copy-Item -Path (Join-Path -Path $moduleRoot -ChildPath ('{0}.psm1' -f $env:BHProjectName)) -Destination $stage
+        Copy-Item -Path (Join-Path -Path $moduleRoot -ChildPath 'Public') -Destination $stage -Recurse
+        (Test-Path -Path (Join-Path -Path $stage -ChildPath 'Private') -PathType Container) | Should -BeFalse
+
+        $stagedManifest = Join-Path -Path $stage -ChildPath ('{0}.psd1' -f $env:BHProjectName)
+        Get-Module -Name $env:BHProjectName -All | Remove-Module -Force -ErrorAction 'SilentlyContinue'
+        { Import-Module -Name $stagedManifest -Force } | Should -Not -Throw
+    }
+
+    It -Name 'does not warn about missing openssl when openssl is on PATH' -Skip:($IsWindows) -Test {
+        # Linux/macOS branch checks @('/usr/bin','/usr/sbin','/sbin','/bin').
+        # Hosted CI runners ship openssl in /usr/bin so this branch should be quiet.
+        Get-Module -Name $env:BHProjectName -All | Remove-Module -Force -ErrorAction 'SilentlyContinue'
+        $warnings = @()
+        Import-Module -Name $env:BHPSModuleManifest -Force -WarningVariable 'warnings' -WarningAction 'SilentlyContinue'
+        ($warnings | Where-Object -FilterScript { $_ -match 'Openssl not found' }) | Should -BeNullOrEmpty
+    }
+}

--- a/Tests/Unit/Loader.Tests.windows.ps1
+++ b/Tests/Unit/Loader.Tests.windows.ps1
@@ -1,0 +1,36 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'PS.SSL module loader (Windows)' -Fixture {
+
+    It -Name 'does not warn about missing openssl when openssl is on $env:Path' -Test {
+        # windows-latest ships Git for Windows which adds C:\Program Files\Git\usr\bin
+        # to $env:Path, where openssl.exe lives. If this assertion fails, the
+        # runner image regressed and the integration suite will silently skip.
+        $env:Path | Should -Match 'openssl|Git\\usr\\bin'
+        Get-Module -Name $env:BHProjectName -All | Remove-Module -Force -ErrorAction 'SilentlyContinue'
+        $warnings = @()
+        Import-Module -Name $env:BHPSModuleManifest -Force -WarningVariable 'warnings' -WarningAction 'SilentlyContinue'
+        ($warnings | Where-Object -FilterScript { $_ -match 'Openssl not found' }) | Should -BeNullOrEmpty
+    }
+
+    It -Name 'warns about missing openssl when openssl is absent from $env:Path' -Test {
+        $originalPath = $env:Path
+        try {
+            $env:Path = ($env:Path -split ';' |
+                Where-Object -FilterScript { $_ -notmatch 'openssl' -and $_ -notmatch 'Git\\usr\\bin' }) -join ';'
+            Get-Module -Name $env:BHProjectName -All | Remove-Module -Force -ErrorAction 'SilentlyContinue'
+            $warnings = @()
+            Import-Module -Name $env:BHPSModuleManifest -Force -WarningVariable 'warnings' -WarningAction 'SilentlyContinue'
+            ($warnings | Where-Object -FilterScript { $_ -match 'Openssl not found' }) | Should -Not -BeNullOrEmpty
+        }
+        finally {
+            $env:Path = $originalPath
+            Get-Module -Name $env:BHProjectName -All | Remove-Module -Force -ErrorAction 'SilentlyContinue'
+            Import-Module -Name $env:BHPSModuleManifest -Force
+        }
+    }
+}

--- a/Tests/Unit/Loader.Tests.windows.ps1
+++ b/Tests/Unit/Loader.Tests.windows.ps1
@@ -6,15 +6,18 @@ BeforeDiscovery {
 
 Describe -Name 'PS.SSL module loader (Windows)' -Fixture {
 
+    # Import-Module's -WarningVariable does not capture Write-Warning calls
+    # emitted from a module's .psm1 body, so redirect the warning stream
+    # (3>&1) and filter for [WarningRecord] instead.
     It -Name 'does not warn about missing openssl when openssl is on $env:Path' -Test {
         # windows-latest ships Git for Windows which adds C:\Program Files\Git\usr\bin
         # to $env:Path, where openssl.exe lives. If this assertion fails, the
         # runner image regressed and the integration suite will silently skip.
         $env:Path | Should -Match 'openssl|Git\\usr\\bin'
         Get-Module -Name $env:BHProjectName -All | Remove-Module -Force -ErrorAction 'SilentlyContinue'
-        $warnings = @()
-        Import-Module -Name $env:BHPSModuleManifest -Force -WarningVariable 'warnings' -WarningAction 'SilentlyContinue'
-        ($warnings | Where-Object -FilterScript { $_ -match 'Openssl not found' }) | Should -BeNullOrEmpty
+        $warnings = & { Import-Module -Name $env:BHPSModuleManifest -Force } 3>&1 |
+            Where-Object -FilterScript { $_ -is [System.Management.Automation.WarningRecord] }
+        ($warnings | Where-Object -FilterScript { $_.Message -match 'Openssl not found' }) | Should -BeNullOrEmpty
     }
 
     It -Name 'warns about missing openssl when openssl is absent from $env:Path' -Test {
@@ -23,9 +26,9 @@ Describe -Name 'PS.SSL module loader (Windows)' -Fixture {
             $env:Path = ($env:Path -split ';' |
                 Where-Object -FilterScript { $_ -notmatch 'openssl' -and $_ -notmatch 'Git\\usr\\bin' }) -join ';'
             Get-Module -Name $env:BHProjectName -All | Remove-Module -Force -ErrorAction 'SilentlyContinue'
-            $warnings = @()
-            Import-Module -Name $env:BHPSModuleManifest -Force -WarningVariable 'warnings' -WarningAction 'SilentlyContinue'
-            ($warnings | Where-Object -FilterScript { $_ -match 'Openssl not found' }) | Should -Not -BeNullOrEmpty
+            $warnings = & { Import-Module -Name $env:BHPSModuleManifest -Force } 3>&1 |
+                Where-Object -FilterScript { $_ -is [System.Management.Automation.WarningRecord] }
+            ($warnings | Where-Object -FilterScript { $_.Message -match 'Openssl not found' }) | Should -Not -BeNullOrEmpty
         }
         finally {
             $env:Path = $originalPath


### PR DESCRIPTION
## Summary
- Run `validate` on `ubuntu-latest` and `windows-latest` (matrix, `fail-fast: false`, `timeout-minutes: 15`); per-OS artifact + test-reporter names so both OSes surface side-by-side.
- `Build/build.psake.ps1`: discover `*.Tests.windows.ps1` only on Windows runners (SecurityTools naming convention).
- Loader coverage:
  - `Tests/Unit/Loader.Tests.ps1` — clean import, tolerates missing `Private/`, no openssl warning when on Linux/macOS PATH.
  - `Tests/Unit/Loader.Tests.windows.ps1` — Windows openssl PATH discovery (quiet when present, warns when removed).

## Test plan
- [x] Local: `Build/build.ps1 -TaskList CombineFunctionsAndStage,Analyze,Test,Cleanup` → 336 passed / 0 failed / 14 NotRun (Network-tagged + Windows-only) on macOS.
- [ ] CI: both matrix legs green, per-OS Pester results published.

Closes #37