### PR TITLE
fix(Public): default OutputDirectory to Join-Path $HOME 'Desktop' (closes #53)

### DIFF
--- a/Public/ConvertFrom-PKCS7.ps1
+++ b/Public/ConvertFrom-PKCS7.ps1
@@ -26,7 +26,7 @@ function ConvertFrom-PKCS7 {
 
         [Parameter(HelpMessage = 'Output directory for generated files')]
         [ValidateScript({ Test-OutputDirectoryPath -Path $_ })]
-        [System.String] $OutputDirectory = "$HOME\Desktop"
+        [System.String] $OutputDirectory = (Join-Path -Path $HOME -ChildPath 'Desktop')
     )
     Begin {
         Write-Verbose -Message "Starting $($MyInvocation.Mycommand)"

--- a/Public/ConvertTo-PEM.ps1
+++ b/Public/ConvertTo-PEM.ps1
@@ -29,7 +29,7 @@ function ConvertTo-PEM {
 
         [Parameter(HelpMessage = 'Output directory for generated files')]
         [ValidateScript({ Test-OutputDirectoryPath -Path $_ })]
-        [System.String] $OutputDirectory = "$HOME\Desktop",
+        [System.String] $OutputDirectory = (Join-Path -Path $HOME -ChildPath 'Desktop'),
 
         [Parameter(Mandatory, HelpMessage = 'Password to PFX file')]
         [ValidateNotNullOrEmpty()]

--- a/Public/Export-CertificateData.ps1
+++ b/Public/Export-CertificateData.ps1
@@ -69,7 +69,7 @@ function Export-CertificateData {
 
         [Parameter(Position = 1, HelpMessage = 'Output directory for generated files')]
         [ValidateScript({ Test-OutputDirectoryPath -Path $_ })]
-        [System.String] $OutputDirectory = "$HOME\Desktop",
+        [System.String] $OutputDirectory = (Join-Path -Path $HOME -ChildPath 'Desktop'),
 
         [Parameter(Mandatory, Position = 2, HelpMessage = 'Data to export')]
         [ValidateSet('Certificate', 'Chain', 'PrivateKey')]

--- a/Public/Export-PFX.ps1
+++ b/Public/Export-PFX.ps1
@@ -34,7 +34,7 @@ function Export-PFX {
     Param(
         [Parameter(HelpMessage = 'Output directory for generated files')]
         [ValidateScript({ Test-OutputDirectoryPath -Path $_ })]
-        [System.String] $OutputDirectory = "$HOME\Desktop",
+        [System.String] $OutputDirectory = (Join-Path -Path $HOME -ChildPath 'Desktop'),
 
         [Parameter(Mandatory, HelpMessage = 'Password used to protect exported PFX file')]
         [ValidateNotNullOrEmpty()]

--- a/Public/New-CertificateSigningRequest.ps1
+++ b/Public/New-CertificateSigningRequest.ps1
@@ -59,7 +59,7 @@ function New-CertificateSigningRequest {
     Param(
         [Parameter(HelpMessage = 'Output directory for generated files')]
         [ValidateScript({ Test-OutputDirectoryPath -Path $_ })]
-        [System.String] $OutputDirectory = "$HOME\Desktop",
+        [System.String] $OutputDirectory = (Join-Path -Path $HOME -ChildPath 'Desktop'),
 
         [Parameter(Mandatory, ParameterSetName = '__conf', HelpMessage = 'Path to configuration template')]
         [ValidateScript({ Test-Path -Path $_ -PathType Leaf -Include '*.conf' })]

--- a/Public/New-SelfSignedCertificate.ps1
+++ b/Public/New-SelfSignedCertificate.ps1
@@ -49,7 +49,7 @@ function New-SelfSignedCertificate {
     Param(
         [Parameter(HelpMessage = 'Output directory for generated files')]
         [ValidateScript({ Test-OutputDirectoryPath -Path $_ })]
-        [System.String] $OutputDirectory = "$HOME\Desktop",
+        [System.String] $OutputDirectory = (Join-Path -Path $HOME -ChildPath 'Desktop'),
 
         [Parameter(HelpMessage = 'Validity period in days (default is 365)')]
         [ValidateRange(30, 3650)]

--- a/Tests/Common/PathLiterals.Tests.ps1
+++ b/Tests/Common/PathLiterals.Tests.ps1
@@ -1,0 +1,28 @@
+BeforeDiscovery {
+    # One TestCase per Public/*.ps1 so failures point at the specific file.
+    $publicDir = Join-Path -Path (Split-Path -Path $env:BHPSModuleManifest -Parent) -ChildPath 'Public'
+    $script:PublicFileCases = foreach ($file in (Get-ChildItem -Path $publicDir -Filter '*.ps1' -File)) {
+        @{ File = $file.Name; FullName = $file.FullName }
+    }
+}
+
+Describe -Name 'Public function path literals' -Fixture {
+
+    # PowerShell on Linux/macOS treats '\' as a literal filename character, not
+    # a path separator. A backslash following $HOME, $PSScriptRoot, $PWD, or
+    # $TestDrive in a string literal is almost always a Windows-ism that breaks
+    # on cross-platform runners. Static scan beats per-instance tests.
+    It -Name 'does not embed backslash after $HOME / $PSScriptRoot / $PWD / $TestDrive in <File>' -TestCases $PublicFileCases -Test {
+        param($File, $FullName)
+        $ast = [System.Management.Automation.Language.Parser]::ParseFile($FullName, [ref] $null, [ref] $null)
+        $offenders = $ast.FindAll({
+                param($node)
+                ($node -is [System.Management.Automation.Language.ExpandableStringExpressionAst] -or
+                    $node -is [System.Management.Automation.Language.StringConstantExpressionAst]) -and
+                $node.Extent.Text -match '\$(HOME|PSScriptRoot|PWD|TestDrive)\\'
+            }, $true)
+        $offenders | Should -BeNullOrEmpty -Because (
+            'found backslash-joined path literal(s): ' + (($offenders | ForEach-Object -Process { $_.Extent.Text }) -join '; ')
+        )
+    }
+}

--- a/Tests/Unit/DefaultPaths.Tests.ps1
+++ b/Tests/Unit/DefaultPaths.Tests.ps1
@@ -1,0 +1,38 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+
+    # Walk every Public/*.ps1 and collect any OutputDirectory parameter whose
+    # default value is a static expression. Each case becomes one It block so
+    # the failure message points to the specific function and its default.
+    $publicDir = Join-Path -Path (Split-Path -Path $env:BHPSModuleManifest -Parent) -ChildPath 'Public'
+    $script:DefaultDirCases = foreach ($file in (Get-ChildItem -Path $publicDir -Filter '*.ps1' -File)) {
+        $ast = [System.Management.Automation.Language.Parser]::ParseFile($file.FullName, [ref] $null, [ref] $null)
+        $params = $ast.FindAll({
+                param($node)
+                $node -is [System.Management.Automation.Language.ParameterAst] -and
+                $node.Name.VariablePath.UserPath -eq 'OutputDirectory' -and
+                $null -ne $node.DefaultValue
+            }, $true)
+        foreach ($p in $params) {
+            @{
+                File        = $file.Name
+                DefaultText = $p.DefaultValue.Extent.Text
+            }
+        }
+    }
+}
+
+Describe -Name 'Public function default OutputDirectory paths' -Fixture {
+
+    # Asserts the resolved default points at $HOME/Desktop on the current OS.
+    # Catches stray '\' literals that Windows tolerates but Linux/macOS treat
+    # as a single filename character (e.g. /home/runner\Desktop).
+    It -Name '<File> default resolves to $HOME/Desktop on the current OS' -TestCases $DefaultDirCases -Test {
+        param($File, $DefaultText)
+        $resolved = & ([System.Management.Automation.ScriptBlock]::Create($DefaultText))
+        (Split-Path -Path $resolved -Leaf)   | Should -Be 'Desktop'
+        (Split-Path -Path $resolved -Parent) | Should -Be $HOME
+    }
+}


### PR DESCRIPTION
## Summary

Six `Public/*.ps1` functions declared `[System.String] $OutputDirectory = "$HOME\Desktop"`. On Linux/macOS the backslash is a literal filename character, so the default resolved to e.g. `/home/runner\Desktop` instead of `$HOME/Desktop`. Switched each default to `(Join-Path -Path $HOME -ChildPath 'Desktop')`.

Closes #53.

## Changes

- `Public/ConvertFrom-PKCS7.ps1`, `ConvertTo-PEM.ps1`, `Export-CertificateData.ps1`, `Export-PFX.ps1`, `New-CertificateSigningRequest.ps1`, `New-SelfSignedCertificate.ps1` — replace literal default with `Join-Path` expression.
- `Tests/Unit/DefaultPaths.Tests.ps1` — AST walk over `Public/*.ps1`; for each `$OutputDirectory` default, evaluate it and assert `Parent == $HOME` and `Leaf == 'Desktop'`. One `TestCase` per default.
- `Tests/Common/PathLiterals.Tests.ps1` — static AST scan that flags any string literal in `Public/*.ps1` embedding a backslash directly after `$HOME` / `$PSScriptRoot` / `$PWD` / `$TestDrive`. Prevents the Windows-ism reappearing.

## Validation

- [x] Local: `Build/build.ps1 -TaskList CombineFunctionsAndStage,Analyze,Test,Cleanup` → 357 passed / 0 failed / 14 NotRun on macOS (21 new cases vs. main).
- [ ] CI: `validate (ubuntu-latest)` and `validate (windows-latest)` both green.