### PR TITLE
fix(Public): Test-PrivateKeyCertMatch validator enforces file extensions (closes #54)

### DIFF
--- a/Public/Test-PrivateKeyCertMatch.ps1
+++ b/Public/Test-PrivateKeyCertMatch.ps1
@@ -46,11 +46,11 @@ function Test-PrivateKeyCertMatch {
     [OutputType([System.Boolean])]
     Param(
         [Parameter(Mandatory, Position = 0, HelpMessage = 'Path to private key file')]
-        [ValidateScript({ Test-Path -Path $_ -PathType Leaf -Include "*.key", "*.pem" })]
+        [ValidateScript({ (Test-Path -Path $_ -PathType Leaf) -and ($_ -match '\.(key|pem)$') })]
         [System.String] $PrivateKeyPath,
 
         [Parameter(Mandatory, Position = 1, ValueFromPipeline, HelpMessage = 'Path to certificate file')]
-        [ValidateScript({ Test-Path -Path $_ -PathType Leaf -Include "*.crt", "*.cer", "*.pem" })]
+        [ValidateScript({ (Test-Path -Path $_ -PathType Leaf) -and ($_ -match '\.(crt|cer|pem)$') })]
         [System.String] $CertificatePath
     )
     Begin {

--- a/Tests/Unit/Test-PrivateKeyCertMatch.Tests.ps1
+++ b/Tests/Unit/Test-PrivateKeyCertMatch.Tests.ps1
@@ -1,0 +1,49 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'Test-PrivateKeyCertMatch' -Fixture {
+
+    Context -Name 'parameter validation' -Fixture {
+
+        It -Name 'rejects -PrivateKeyPath that does not have a .key or .pem extension' -Test {
+            $wrongExt = Join-Path -Path $TestDrive -ChildPath 'notakey.txt'
+            Set-Content -Path $wrongExt -Value 'placeholder'
+            $cert = Join-Path -Path $TestDrive -ChildPath 'cert.pem'
+            Set-Content -Path $cert -Value 'placeholder'
+
+            { Test-PrivateKeyCertMatch -PrivateKeyPath $wrongExt -CertificatePath $cert } |
+                Should -Throw -ExpectedMessage '*PrivateKeyPath*'
+        }
+
+        It -Name 'rejects -CertificatePath that does not have a .crt, .cer, or .pem extension' -Test {
+            $key = Join-Path -Path $TestDrive -ChildPath 'key.key'
+            Set-Content -Path $key -Value 'placeholder'
+            $wrongExt = Join-Path -Path $TestDrive -ChildPath 'notacert.txt'
+            Set-Content -Path $wrongExt -Value 'placeholder'
+
+            { Test-PrivateKeyCertMatch -PrivateKeyPath $key -CertificatePath $wrongExt } |
+                Should -Throw -ExpectedMessage '*CertificatePath*'
+        }
+
+        It -Name 'rejects -PrivateKeyPath that does not exist' -Test {
+            $cert = Join-Path -Path $TestDrive -ChildPath 'cert.pem'
+            Set-Content -Path $cert -Value 'placeholder'
+            $missing = Join-Path -Path $TestDrive -ChildPath 'missing.key'
+
+            { Test-PrivateKeyCertMatch -PrivateKeyPath $missing -CertificatePath $cert } |
+                Should -Throw -ExpectedMessage '*PrivateKeyPath*'
+        }
+
+        It -Name 'rejects -CertificatePath that does not exist' -Test {
+            $key = Join-Path -Path $TestDrive -ChildPath 'key.key'
+            Set-Content -Path $key -Value 'placeholder'
+            $missing = Join-Path -Path $TestDrive -ChildPath 'missing.pem'
+
+            { Test-PrivateKeyCertMatch -PrivateKeyPath $key -CertificatePath $missing } |
+                Should -Throw -ExpectedMessage '*CertificatePath*'
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`Test-PrivateKeyCertMatch`'s `ValidateScript` on `-PrivateKeyPath` and `-CertificatePath` used `Test-Path -Include`, which only filters when `-Path` contains a wildcard. For literal paths the extension filter was silently ignored, so `./notakey.txt` was accepted and the call only failed deep inside openssl with an opaque exit-code error. Switched both validators to a `Test-Path` + regex compound expression that actually enforces the documented extensions.

Closes #54.

## Changes

- `Public/Test-PrivateKeyCertMatch.ps1` — replace `ValidateScript` on both parameters with `(Test-Path -Path $_ -PathType Leaf) -and ($_ -match '\.(key|pem)$')` / `(\.(crt|cer|pem)$)`.
- `Tests/Unit/Test-PrivateKeyCertMatch.Tests.ps1` — new file. Four cases under `Context 'parameter validation'`: wrong-extension and missing-file rejection on each parameter. Each assertion uses `Should -Throw -ExpectedMessage '*<ParamName>*'` so the failure attributes the rejection to the right parameter.

## Validation

- [x] Local: `Build/build.ps1 -TaskList CombineFunctionsAndStage,Analyze,Test,Cleanup` → 361 passed / 0 failed / 14 NotRun on macOS (4 new cases vs. main).
- [ ] CI: `validate (ubuntu-latest)` and `validate (windows-latest)` both green.