### PR TITLE
chore(release): bump module version to 0.3.3

### DIFF
--- a/PS.SSL.psd1
+++ b/PS.SSL.psd1
@@ -12,7 +12,7 @@
     # Major = significant changes, breaking changes or major new features
     # Minor = new functions or features
     # Build = bug fixes and minor updates
-    ModuleVersion     = '0.3.2'
+    ModuleVersion     = '0.3.3'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()


### PR DESCRIPTION
## Summary

Bump module version from `0.3.2` to `0.3.3` to release the two cross-platform bug fixes merged since the last tag.

## Changes

- `PS.SSL.psd1`: `ModuleVersion = '0.3.3'`

## Included fixes

- #55 — `$HOME\Desktop` default broke `New-SelfSignedCertificate` and friends on Linux/macOS; switched to `Join-Path`. Added AST-driven guard tests (`DefaultPaths.Tests.ps1`, `PathLiterals.Tests.ps1`).
- #56 — `Test-PrivateKeyCertMatch` `[ValidateScript]` only checked `Test-Path` and silently accepted any extension; now enforces `.key`/`.pem` (private key) and `.crt`/`.cer`/`.pem` (certificate).

## Validation

- [ ] CI green on `validate (ubuntu-latest)` and `validate (windows-latest)`